### PR TITLE
Cache audio file lookups

### DIFF
--- a/modules/audio_utils.py
+++ b/modules/audio_utils.py
@@ -13,7 +13,7 @@ import os
 
 # Se asume que la función buscar_archivos está definida en file_utils.py
 from modules.character_manager import get_personajes_features
-from modules.file_utils import buscar_archivos
+from modules.file_utils import buscar_archivos, buscar_en_indice
 from config import AUDIO_PATH, valor_A, valor_B
 
 def get_dict_voces():
@@ -83,7 +83,7 @@ def extraer_informacion_audio(ruta):
     return detalles_audio
 
 
-def get_sonidos_rutas(sonidos_personas, audio_path = AUDIO_PATH):
+def get_sonidos_rutas(sonidos_personas, audio_path=AUDIO_PATH, indice=None):
     """
     Dado un diccionario de sonidos (con nombres y rutas o lista de rutas),
     busca los archivos de audio en la ruta especificada en 'audio_path' utilizando
@@ -102,22 +102,23 @@ def get_sonidos_rutas(sonidos_personas, audio_path = AUDIO_PATH):
     for key, v in sonidos_personas.items():
         ls_rutas = []
         if isinstance(v, list):
-            for x in v:
-                x_agender = x.replace(' (man)', '').replace(' (woman)', '') \
-                             .replace(' (men)', '').replace(' (women)', '')
-                res_ = buscar_archivos(audio_path, x_agender)
-                if len(res_) == 0:
-                    print(key, ":_", x)
-                else:
-                    ls_rutas.append(extraer_informacion_audio(res_[0]))
+            nombres = v
         else:
-            v_agender = v.replace(' (man)', '').replace(' (woman)', '') \
-                         .replace(' (men)', '').replace(' (women)', '')
-            res_ = buscar_archivos(audio_path, v_agender)
+            nombres = [v]
+
+        for nombre in nombres:
+            nombre_agender = nombre.replace(' (man)', '').replace(' (woman)', '') \
+                                    .replace(' (men)', '').replace(' (women)', '')
+            if indice is not None:
+                res_ = buscar_en_indice(indice, nombre_agender)
+            else:
+                res_ = buscar_archivos(audio_path, nombre_agender)
+
             if len(res_) == 0:
-                print(key, ":", v)
+                print(key, ":" if not isinstance(v, list) else ":_", nombre)
             else:
                 ls_rutas.append(extraer_informacion_audio(res_[0]))
+
         sonidos_rutas[key] = ls_rutas
     return sonidos_rutas
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,54 @@
+import os
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import modules.file_utils as fu
+import modules.audio_utils as au
+
+
+def _create_dummy_audio(dir_path):
+    # create a fake mp3 file
+    file_path = os.path.join(dir_path, "sonido.mp3")
+    with open(file_path, "w") as f:
+        f.write("dummy")
+    return file_path
+
+
+def test_buscar_archivos_caches_walk():
+    with TemporaryDirectory() as tmp:
+        _create_dummy_audio(tmp)
+        fu.limpiar_indices()
+        with patch("modules.file_utils.os.walk", wraps=os.walk) as mock_walk:
+            fu.buscar_archivos(tmp, "sonido")
+            assert mock_walk.call_count == 1
+            fu.buscar_archivos(tmp, "sonido")
+            assert mock_walk.call_count == 1
+
+
+def test_get_sonidos_rutas_uses_cache():
+    with TemporaryDirectory() as tmp:
+        _create_dummy_audio(tmp)
+        fu.limpiar_indices()
+        sonidos = {"p1": "sonido"}
+        with patch("modules.audio_utils.extraer_informacion_audio", lambda r: {"ruta": r}), \
+             patch("modules.file_utils.os.walk", wraps=os.walk) as mock_walk:
+            au.get_sonidos_rutas(sonidos, audio_path=tmp)
+            assert mock_walk.call_count == 1
+            au.get_sonidos_rutas(sonidos, audio_path=tmp)
+            assert mock_walk.call_count == 1
+
+
+def test_get_sonidos_rutas_with_precomputed_index():
+    with TemporaryDirectory() as tmp:
+        _create_dummy_audio(tmp)
+        fu.limpiar_indices()
+        sonidos = {"p1": "sonido"}
+        with patch("modules.audio_utils.extraer_informacion_audio", lambda r: {"ruta": r}), \
+             patch("modules.file_utils.os.walk", wraps=os.walk) as mock_walk:
+            indice = fu.obtener_indice(tmp)
+            mock_walk.reset_mock()
+            au.get_sonidos_rutas(sonidos, audio_path=tmp, indice=indice)
+            assert mock_walk.call_count == 0


### PR DESCRIPTION
## Summary
- cache normalized filenames the first time audio directories are walked
- allow `get_sonidos_rutas` to use cached or precomputed indices
- add tests verifying repeated searches avoid disk access

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b36b977ab0832ca489bc2220db2116