### PR TITLE
Add habilidades assets

### DIFF
--- a/habilidades/auditar-paridad-maas/SKILL.md
+++ b/habilidades/auditar-paridad-maas/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: auditar-paridad-maas
+description: Mide y documenta paridad visual, temporal, sonora y funcional entre el reproductor MAAS HTML y los outputs legados. Usar para golden tests, SSIM, drift de cues, aceptación de perfiles y generación de evidencia auditable.
+---
+
+# Auditar paridad MAAS
+
+1. Leer `references/golden-corpus.md` y fijar input, assets, seed, orientación y perfil.
+2. Comparar timelines con `scripts/compare_timelines.py`.
+3. Comparar frames con `scripts/compare_frames.py`; usar umbrales de `references/acceptance-criteria.md`.
+4. Registrar excepciones únicamente en `references/known-differences.md`, con causa y aprobación.
+5. Consolidar reportes mediante `scripts/generate_audit_report.py`.
+6. No aprobar `canonical-v1` por resultados de `legacy-v1`; cada perfil tiene baseline independiente.
+
+## Guardas
+
+- No comparar archivos sin demostrar que pertenecen al mismo episodio/seed.
+- Conservar capturas originales y hashes.
+- Reportar fallos; nunca redondear métricas para ocultar desviaciones.
+- Requerir revisión humana de transiciones, captions y audio además de métricas.

--- a/habilidades/auditar-paridad-maas/agents/openai.yaml
+++ b/habilidades/auditar-paridad-maas/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Auditar paridad MAAS"
+  short_description: "Compara HTML, timeline y video legado"
+  default_prompt: "Usa $auditar-paridad-maas para medir la paridad del reproductor HTML con el video legado."

--- a/habilidades/auditar-paridad-maas/references/acceptance-criteria.md
+++ b/habilidades/auditar-paridad-maas/references/acceptance-criteria.md
@@ -1,0 +1,23 @@
+# Criterios de aceptación
+
+## Legacy-v1
+
+- Drift de inicio/duración visual: máximo 40 ms.
+- Drift de audio: máximo 20 ms.
+- Posiciones y tamaños: máximo 2 px a resolución lógica.
+- SSIM escena estática: mínimo 0.97.
+- SSIM durante temblor: mínimo 0.93.
+- Mismo input/assets/seed: mismos hashes de manifiesto.
+- Cero secretos, assets bloqueados o errores de consola.
+
+## Funcional
+
+- Play, pause, seek, mute, volumen, captions y orientación.
+- Teclado y focus visibles.
+- `prefers-reduced-motion` no altera tiempos/audio.
+- Recuperación de autoplay bloqueado y `AudioContext` suspendido.
+- Landscape, portrait y resize sin deformación.
+
+## Reporte
+
+Cada caso incluye ID, input SHA, asset manifest SHA, profile, orientación, navegador, viewport, frame/cue, expected, actual, métrica, umbral, pass/fail y enlace relativo a evidencia.

--- a/habilidades/auditar-paridad-maas/references/golden-corpus.md
+++ b/habilidades/auditar-paridad-maas/references/golden-corpus.md
@@ -1,0 +1,26 @@
+# Corpus golden
+
+Seleccionar al menos:
+
+1. Escena corta con cada código de cámara.
+2. Escena con PP, sprite grande y ambos lados.
+3. OSD corto, largo y silencio.
+4. Dos escenas con transición.
+5. Landscape y portrait del mismo episodio.
+6. Un episodio extenso con múltiples speakers.
+
+Por cada caso guardar únicamente lo necesario:
+
+```text
+tests/golden/<case>/
+├── source.json
+├── character-map.json
+├── asset-manifest.slice.json
+├── expected-timeline.json
+├── expected-frames/<timestamp>.png
+└── provenance.json
+```
+
+`provenance.json` registra video/frame legado, SHA-256, comando de extracción y relación demostrada con el input. Si no puede demostrarse la relación, marcar `referenceOnly=true` y excluir de gates automáticos.
+
+No migrar videos completos cuando basten frames y pequeños fragmentos autorizados.

--- a/habilidades/auditar-paridad-maas/references/known-differences.md
+++ b/habilidades/auditar-paridad-maas/references/known-differences.md
@@ -1,0 +1,14 @@
+# Diferencias conocidas
+
+Toda entrada debe contener: ID, perfil, fecha, comportamiento legado, comportamiento web, causa, impacto, evidencia, decisión y aprobador.
+
+Baseline inicial:
+
+- Rasterización de Nanum Gothic puede variar ligeramente entre PIL y navegador; no justifica diferencias de wrapping.
+- Compresión JPEG/MP4 introduce ruido que reduce SSIM en bordes.
+- `PA-I` y `PA-D` son idénticos en legacy y opuestos en canonical.
+- `ES` conserva temblor en legacy y es estático en canonical.
+- canonical conserva milisegundos; legacy trunca a segundos enteros.
+- La selección aleatoria histórica sin seed no es reproducible; el baseline debe fijar el asset observado y el nuevo seed.
+
+No añadir tolerancias globales para resolver un caso aislado.

--- a/habilidades/auditar-paridad-maas/scripts/compare_frames.py
+++ b/habilidades/auditar-paridad-maas/scripts/compare_frames.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Calcula MAE y SSIM global entre dos frames usando Pillow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def metrics(expected: Path, actual: Path) -> dict:
+    try:
+        from PIL import Image, ImageChops, ImageStat  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError("Pillow es requerido para comparar frames") from exc
+    with Image.open(expected) as left_image, Image.open(actual) as right_image:
+        left = left_image.convert("L")
+        right = right_image.convert("L")
+        if left.size != right.size:
+            return {"sameSize": False, "expectedSize": left.size, "actualSize": right.size, "mae": None, "ssim": None}
+        diff = ImageChops.difference(left, right)
+        mae = ImageStat.Stat(diff).mean[0] / 255.0
+        left_stat, right_stat = ImageStat.Stat(left), ImageStat.Stat(right)
+        mu_x, mu_y = left_stat.mean[0], right_stat.mean[0]
+        var_x, var_y = left_stat.var[0], right_stat.var[0]
+        pixels_x, pixels_y = list(left.getdata()), list(right.getdata())
+        covariance = sum((x - mu_x) * (y - mu_y) for x, y in zip(pixels_x, pixels_y)) / max(1, len(pixels_x) - 1)
+        c1, c2 = (0.01 * 255) ** 2, (0.03 * 255) ** 2
+        ssim = ((2 * mu_x * mu_y + c1) * (2 * covariance + c2)) / ((mu_x**2 + mu_y**2 + c1) * (var_x + var_y + c2))
+        return {"sameSize": True, "width": left.width, "height": left.height, "mae": mae, "ssim": ssim}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("expected", type=Path)
+    parser.add_argument("actual", type=Path)
+    parser.add_argument("--minimum-ssim", type=float, default=0.97)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    try:
+        result = metrics(args.expected, args.actual)
+    except (OSError, RuntimeError) as exc:
+        print(json.dumps({"valid": False, "error": str(exc)}, ensure_ascii=False))
+        return 1
+    result["minimumSsim"] = args.minimum_ssim
+    result["valid"] = bool(result["sameSize"] and result["ssim"] is not None and result["ssim"] >= args.minimum_ssim)
+    payload = json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload, encoding="utf-8", newline="\n")
+    print(payload, end="")
+    return 0 if result["valid"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/habilidades/auditar-paridad-maas/scripts/compare_timelines.py
+++ b/habilidades/auditar-paridad-maas/scripts/compare_timelines.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Compara cues por ID y aplica límites de drift temporal."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("expected", type=Path)
+    parser.add_argument("actual", type=Path)
+    parser.add_argument("--visual-tolerance-ms", type=int, default=40)
+    parser.add_argument("--audio-tolerance-ms", type=int, default=20)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    expected_data = json.loads(args.expected.read_text(encoding="utf-8"))
+    actual_data = json.loads(args.actual.read_text(encoding="utf-8"))
+    expected = {cue["id"]: cue for cue in expected_data.get("timeline", expected_data)}
+    actual = {cue["id"]: cue for cue in actual_data.get("timeline", actual_data)}
+    cases = []
+    for cue_id in sorted(set(expected) | set(actual)):
+        left, right = expected.get(cue_id), actual.get(cue_id)
+        if left is None or right is None:
+            cases.append({"id": cue_id, "pass": False, "reason": "cue ausente", "expected": left is not None, "actual": right is not None})
+            continue
+        start_drift = abs(int(left["startMs"]) - int(right["startMs"]))
+        duration_drift = abs(int(left["durationMs"]) - int(right["durationMs"]))
+        tolerance = args.audio_tolerance_ms if left.get("audio") else args.visual_tolerance_ms
+        cases.append({"id": cue_id, "pass": max(start_drift, duration_drift) <= tolerance, "startDriftMs": start_drift, "durationDriftMs": duration_drift, "toleranceMs": tolerance})
+    report = {"valid": all(case["pass"] for case in cases), "cases": cases}
+    payload = json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload, encoding="utf-8", newline="\n")
+    print(payload, end="")
+    return 0 if report["valid"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/habilidades/auditar-paridad-maas/scripts/generate_audit_report.py
+++ b/habilidades/auditar-paridad-maas/scripts/generate_audit_report.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Consolida reportes JSON y produce evidencia JSON/HTML segura."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("reports", nargs="+", type=Path)
+    parser.add_argument("--json-output", type=Path, required=True)
+    parser.add_argument("--html-output", type=Path, required=True)
+    args = parser.parse_args()
+    entries = []
+    for path in args.reports:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        entries.append({"path": path.as_posix(), "valid": bool(data.get("valid")), "data": data})
+    summary = {"valid": all(entry["valid"] for entry in entries), "passed": sum(entry["valid"] for entry in entries), "total": len(entries), "reports": entries}
+    args.json_output.parent.mkdir(parents=True, exist_ok=True)
+    args.json_output.write_text(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8", newline="\n")
+    rows = "".join(f"<tr><td>{html.escape(entry['path'])}</td><td>{'PASS' if entry['valid'] else 'FAIL'}</td><td><pre>{html.escape(json.dumps(entry['data'], ensure_ascii=False, indent=2))}</pre></td></tr>" for entry in entries)
+    document = f"<!doctype html><html lang='es'><meta charset='utf-8'><title>Auditoría MAAS</title><style>body{{font-family:system-ui}}table{{border-collapse:collapse;width:100%}}td,th{{border:1px solid #999;padding:.5rem;vertical-align:top}}pre{{white-space:pre-wrap}}</style><h1>Auditoría MAAS: {'PASS' if summary['valid'] else 'FAIL'}</h1><p>{summary['passed']}/{summary['total']} reportes válidos.</p><table><thead><tr><th>Reporte</th><th>Estado</th><th>Detalle</th></tr></thead><tbody>{rows}</tbody></table></html>"
+    args.html_output.parent.mkdir(parents=True, exist_ok=True)
+    args.html_output.write_text(document, encoding="utf-8", newline="\n")
+    print(json.dumps({"valid": summary["valid"], "json": str(args.json_output), "html": str(args.html_output)}, ensure_ascii=False))
+    return 0 if summary["valid"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/habilidades/compilar-guion-maas/SKILL.md
+++ b/habilidades/compilar-guion-maas/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: compilar-guion-maas
+description: Normaliza JSON históricos y compila la gramática textual de MAAS a episode.manifest.json determinista. Usar al importar Guiones/capitulos, resolver personajes y emociones, calcular cues o diagnosticar errores de parsing sin ejecutar TTS ni render de video.
+---
+
+# Compilar guion MAAS
+
+1. Validar el input con `$definir-contratos-maas`.
+2. Para JSON históricos, ejecutar `scripts/normalize_legacy_input.py` y conservar el reporte emitido por stderr.
+3. Leer `references/parsing-rules.md`; no copiar los efectos secundarios del parser legado.
+4. Proporcionar mappings explícitos de personajes y emociones según las referencias.
+5. Ejecutar `scripts/compile_episode.py INPUT --profile legacy-v1 --output episode.manifest.json`.
+6. Validar el manifiesto producido y conservar warnings.
+
+## Reglas
+
+- No llamar OpenAI ni ElevenLabs durante parsing.
+- No escribir scripts intermedios, renombrar inputs ni elegir lugares al azar.
+- Mantener orden del documento, seed y serialización estable.
+- Tratar aliases no resueltos como identidad solo en `legacy-v1`; en `canonical-v1`, exigir mapping.

--- a/habilidades/compilar-guion-maas/agents/openai.yaml
+++ b/habilidades/compilar-guion-maas/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Compilar guion MAAS"
+  short_description: "Convierte guiones en timelines canónicas"
+  default_prompt: "Usa $compilar-guion-maas para compilar un guion MAAS a un manifiesto canónico."

--- a/habilidades/compilar-guion-maas/references/character-resolution.md
+++ b/habilidades/compilar-guion-maas/references/character-resolution.md
@@ -1,0 +1,22 @@
+# Resolución de personajes
+
+El input usa aliases narrativos; el renderer usa IDs de assets.
+
+Prioridad:
+
+1. Mapping persistido del episodio.
+2. Alias exacto del asset manifest.
+3. Coincidencia Unicode casefold del nombre canónico.
+4. En `legacy-v1`, identidad con `W_CHARACTER_IDENTITY` si no se solicitó validación de assets.
+5. En `canonical-v1`, `E_CHARACTER`.
+
+Una resolución mediante IA debe ejecutarse fuera del compilador, guardarse como JSON revisable y volver a entrar como mapping. Nunca hacer una llamada no determinista dentro del build.
+
+Formato:
+
+```json
+{
+  "Jefe": "rinoceronte-rojo",
+  "Empleado_1": "cactus"
+}
+```

--- a/habilidades/compilar-guion-maas/references/emotion-resolution.md
+++ b/habilidades/compilar-guion-maas/references/emotion-resolution.md
@@ -1,0 +1,11 @@
+# Resolución de emociones
+
+Normalizar trim y Unicode casefold, pero conservar el valor original en `sourceEmotion`.
+
+Categorías visuales: `happy`, `sad`, `angry`, `serious`, `worried`, `surprised`, `dizzy`, `confused`, `scared`, `cute`, `realistic`, `a`.
+
+El mapping debe estar versionado. Si el sprite exacto falta, recorrer un fallback declarado y finito, por ejemplo `worried → sad → serious → realistic → a`. Detectar ciclos.
+
+- `legacy-v1`: emoción desconocida puede usar `happy` con warning explícito.
+- `canonical-v1`: emoción desconocida es error.
+- Nunca seleccionar el primer archivo del directorio ni usar aleatoriedad.

--- a/habilidades/compilar-guion-maas/references/parsing-rules.md
+++ b/habilidades/compilar-guion-maas/references/parsing-rules.md
@@ -1,0 +1,36 @@
+# Reglas de compilación
+
+## Índice
+
+1. Fases
+2. Estado del parser
+3. Tiempos sin audio
+4. Recuperación legado
+
+## 1. Fases
+
+1. Normalizar encoding y saltos de línea.
+2. Validar el contenedor.
+3. Tokenizar headers, diálogo, OSD, lugares y transiciones conservando línea original.
+4. Formar una escena desde el primer header hasta `**LUGAR**`.
+5. Resolver personaje, emoción, sprite y sonido mediante manifests explícitos.
+6. Calcular tiempos y producir cues.
+7. Serializar con claves ordenadas.
+
+## 2. Estado del parser
+
+Un header activa personaje, duración, emoción y dirección actoral. Cada diálogo hereda esos valores hasta el siguiente header. El lugar cierra la escena completa; una transición genera un cue independiente entre escenas.
+
+No eliminar apóstrofes, OSD consecutivos ni líneas repetidas. No usar Pandas para asignar posiciones: el manifest registra `speakerOrder` y el renderer decide layout.
+
+## 3. Tiempos sin audio
+
+Si no existe duración de audio, repartir la duración declarada entre las líneas del header y aplicar mínimo 2000 ms por cue en `legacy-v1`. En `canonical-v1`, repartir sin mínimo y exigir al menos 40 ms. Cuando haya audio, `$sincronizar-audio-maas` recalcula `resolvedDurationMs`.
+
+## 4. Recuperación legado
+
+- Normalizar `ZO1.2` a `ZO*1.2` con warning.
+- Reconocer `N segundo(s)` y `MM:SS`.
+- Permitir prefijos numéricos `1. ` solo en importación y eliminarlos del texto final.
+- Conservar header editorial como metadata, no como diálogo.
+- Si falta lugar, fallar; el comportamiento histórico aleatorio no es reproducible.

--- a/habilidades/compilar-guion-maas/scripts/compile_episode.py
+++ b/habilidades/compilar-guion-maas/scripts/compile_episode.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Compila un episode-source JSON a una timeline MAAS determinista."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+HERE = Path(__file__).resolve().parent
+NORMALIZER_PATH = HERE / "normalize_legacy_input.py"
+spec = importlib.util.spec_from_file_location("maas_normalizer", NORMALIZER_PATH)
+normalizer = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(normalizer)
+
+HEADER_RE = re.compile(r"^\s*\[([^\]]+)\]\s*\(([^|]+)\|([^|]+)\|([^)]*)\)\s*$")
+LEGACY_HEADER_RE = re.compile(r"^\s*\[([^\]]+)\]\s*\(([^|]+)\|([^|]+)\|([^)]*)\)\)+\s*$")
+PLACE_RE = re.compile(r"^\s*\*\*([^*]+)\*\*\s*$")
+TRANSITION_RE = re.compile(r"^\s*---(.+?)---\s*$")
+CAMERA_RE = re.compile(r"\((ES|ZI|ZO|PA-I|PA-D|TI-A|TI-B|PP)(?:\*([0-9]+(?:\.[0-9]+)?))?(?:\s+([^()]+))?\)\s*$")
+CAMERA_ANY_RE = re.compile(r"\((ES|ZI|ZO|PA-I|PA-D|TI-A|TI-B|PP)(?:\*([0-9]+(?:\.[0-9]+)?))?(?:\s+([^()]+))?\)")
+NUMBER_PREFIX_RE = re.compile(r"^\s*\d+(?:\.\s*|\s+)")
+
+EMOTIONS = {
+    "felicidad": "happy", "alegría": "happy", "entusiasmo": "happy", "curiosidad": "happy",
+    "ironía": "happy", "sarcasmo": "happy", "alivio": "happy", "tristeza": "sad",
+    "resignación": "sad", "enojo": "angry", "frustración": "angry", "exasperación": "angry",
+    "seriedad": "serious", "serio": "serious", "preocupación": "worried", "miedo": "worried",
+    "sorpresa": "surprised", "confusión": "confused", "cansancio": "sad", "pensamiento": "a",
+}
+
+
+def parse_duration(value: str) -> int:
+    value = value.strip().lower()
+    seconds = re.fullmatch(r"([0-9]+)\s+segundos?", value)
+    if seconds:
+        return int(seconds.group(1)) * 1000
+    clock = re.fullmatch(r"([0-9]{1,2}):([0-5][0-9])", value)
+    if clock:
+        return (int(clock.group(1)) * 60 + int(clock.group(2))) * 1000
+    raise ValueError(f"E_DURATION: {value}")
+
+
+def effect_from(line: str, profile: str, warnings: list[dict[str, Any]], line_no: int) -> tuple[str, dict[str, Any]]:
+    match = CAMERA_RE.search(line)
+    if not match and profile == "legacy-v1":
+        matches = list(CAMERA_ANY_RE.finditer(line))
+        if matches:
+            match = matches[-1]
+            warnings.append({"code": "W_TRAILING_DIALOGUE_METADATA", "line": line_no, "value": line[match.end():].strip()})
+    if not match:
+        if profile == "legacy-v1":
+            warnings.append({"code": "W_MISSING_CAMERA_STATIC", "line": line_no, "value": line})
+            return NUMBER_PREFIX_RE.sub("", line.strip()), {"code": "ES", "intensity": 1.0, "target": None, "tremor": True}
+        raise ValueError(f"E_DIALOGUE_CAMERA: {line}")
+    text = (line[: match.start()] + line[match.end():]).strip()
+    text = NUMBER_PREFIX_RE.sub("", text)
+    code, intensity, target = match.groups()
+    return text, {"code": code, "intensity": float(intensity or 1.0), "target": target.strip() if target else None, "tremor": True}
+
+
+def resolve_emotion(source: str, profile: str, warnings: list[dict[str, Any]], line: int) -> str:
+    key = source.strip().split()[0].casefold()
+    if key in EMOTIONS:
+        return EMOTIONS[key]
+    if profile == "legacy-v1":
+        warnings.append({"code": "W_EMOTION_HAPPY_FALLBACK", "line": line, "value": source})
+        return "happy"
+    raise ValueError(f"E_EMOTION line {line}: {source}")
+
+
+def compile_document(data: dict, profile: str, character_map: dict[str, str]) -> dict:
+    content = data["content"].replace("\r\n", "\n").replace("\r", "\n")
+    warnings: list[dict[str, Any]] = []
+    timeline: list[dict[str, Any]] = []
+    characters: dict[str, str] = {}
+    active: dict[str, Any] | None = None
+    pending: list[dict[str, Any]] = []
+    scene_number = cue_number = 0
+    cursor = 0
+
+    def next_id() -> str:
+        nonlocal cue_number
+        cue_number += 1
+        return f"cue-{cue_number:04d}"
+
+    def flush_scene(place: str, line: int) -> None:
+        nonlocal cursor, scene_number, pending
+        if not pending:
+            raise ValueError(f"E_PLACE line {line}: escena vacía")
+        scene_number += 1
+        scene_start = cursor
+        for item in pending:
+            item["startMs"] = cursor
+            cursor += item["durationMs"]
+        scene = {"id": f"scene-{scene_number:04d}", "type": "scene", "startMs": scene_start, "durationMs": cursor - scene_start, "place": place.strip(), "cueIds": [x["id"] for x in pending]}
+        timeline.append(scene)
+        timeline.extend(pending)
+        pending = []
+
+    lines = content.split("\n")
+    dialogue_counts: dict[int, int] = {}
+    header_index = -1
+    for raw in lines:
+        if HEADER_RE.fullmatch(raw) or (profile == "legacy-v1" and LEGACY_HEADER_RE.fullmatch(raw)):
+            header_index += 1
+            dialogue_counts[header_index] = 0
+        elif raw.strip() and not PLACE_RE.fullmatch(raw) and not TRANSITION_RE.fullmatch(raw):
+            if header_index >= 0:
+                dialogue_counts[header_index] += 1
+
+    header_index = -1
+    for line_no, raw in enumerate(lines, 1):
+        line = raw.strip()
+        if not line:
+            continue
+        header = HEADER_RE.fullmatch(raw)
+        if not header and profile == "legacy-v1":
+            header = LEGACY_HEADER_RE.fullmatch(raw)
+            if header:
+                warnings.append({"code": "W_LEGACY_HEADER_PARENTHESES", "line": line_no, "value": raw})
+        if header:
+            header_index += 1
+            alias, duration, source_emotion, stage = (x.strip() for x in header.groups())
+            character_id = character_map.get(alias, alias)
+            if alias not in character_map and profile == "legacy-v1":
+                warnings.append({"code": "W_CHARACTER_IDENTITY", "line": line_no, "value": alias})
+            elif alias not in character_map:
+                raise ValueError(f"E_CHARACTER line {line_no}: {alias}")
+            characters[alias] = character_id
+            active = {
+                "alias": alias,
+                "characterId": character_id,
+                "declaredDurationMs": parse_duration(duration),
+                "emotion": resolve_emotion(source_emotion, profile, warnings, line_no),
+                "sourceEmotion": source_emotion,
+                "stageDirection": stage,
+                "line": line_no,
+                "count": max(1, dialogue_counts.get(header_index, 1)),
+            }
+            continue
+        place = PLACE_RE.fullmatch(raw)
+        if place:
+            flush_scene(place.group(1), line_no)
+            active = None
+            continue
+        transition = TRANSITION_RE.fullmatch(raw)
+        if transition:
+            duration = 1900
+            timeline.append({"id": next_id(), "type": "transition", "startMs": cursor, "durationMs": duration, "text": transition.group(1).strip()})
+            cursor += duration
+            continue
+        if active is None:
+            warnings.append({"code": "W_EDITORIAL_PREFIX", "line": line_no, "value": line})
+            continue
+        text, effect = effect_from(raw, profile, warnings, line_no)
+        cue_type = "dialogue"
+        sound = None
+        if text.upper().startswith("OSD"):
+            sound_match = re.search(r"OSD\s*\((.*?)\)", text, re.IGNORECASE)
+            if not sound_match:
+                raise ValueError(f"E_DIALOGUE_CAMERA line {line_no}: OSD inválido")
+            sound = sound_match.group(1).strip()
+            text = sound
+            cue_type = "sfx"
+        divided = active["declaredDurationMs"] // active["count"]
+        duration = max(2000, divided) if profile == "legacy-v1" else max(40, divided)
+        cue = {
+            "id": next_id(), "type": cue_type, "startMs": 0, "durationMs": duration,
+            "declaredDurationMs": active["declaredDurationMs"], "resolvedDurationMs": duration,
+            "speaker": active["characterId"], "speakerAlias": active["alias"], "text": text,
+            "emotion": active["emotion"], "sourceEmotion": active["sourceEmotion"],
+            "stageDirection": active["stageDirection"], "effect": effect, "sourceLine": line_no,
+        }
+        if sound is not None:
+            cue["sound"] = sound
+        pending.append(cue)
+    if pending:
+        raise ValueError("E_PLACE: el último bloque no termina con **LUGAR**")
+    timeline.sort(key=lambda cue: (cue["startMs"], cue["id"]))
+    return {
+        "schemaVersion": "1.0", "episodeId": data["episodeId"], "title": data["title"],
+        "language": data["language"], "status": data["status"], "seed": data["seed"],
+        "profile": profile, "orientations": ["landscape", "portrait"], "characters": characters,
+        "assets": [], "audioPolicy": {"musicGain": 0.15, "transitionGain": 0.5, "sampleRate": 44100, "muteMusicDuringSfx": True},
+        "timeline": timeline, "durationMs": cursor, "warnings": warnings,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--profile", choices=("legacy-v1", "canonical-v1"), default="legacy-v1")
+    parser.add_argument("--character-map", type=Path)
+    args = parser.parse_args()
+    try:
+        source = json.loads(args.input.read_text(encoding="utf-8-sig"))
+        data, normalization_warnings = normalizer.normalize(source)
+        character_map = json.loads(args.character_map.read_text(encoding="utf-8-sig")) if args.character_map else {}
+        manifest = compile_document(data, args.profile, character_map)
+        manifest["warnings"] = normalization_warnings + manifest["warnings"]
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError, TypeError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    payload = json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload, encoding="utf-8", newline="\n")
+        digest = hashlib.sha256(payload.encode()).hexdigest()
+        print(json.dumps({"output": str(args.output), "sha256": digest, "warnings": len(manifest["warnings"])}, ensure_ascii=False))
+    else:
+        sys.stdout.write(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/habilidades/compilar-guion-maas/scripts/normalize_legacy_input.py
+++ b/habilidades/compilar-guion-maas/scripts/normalize_legacy_input.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Convierte el contenedor histórico de MAAS al contrato estricto 1.0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import unicodedata
+from pathlib import Path
+
+
+def slugify(value: str) -> str:
+    ascii_value = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii").lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", ascii_value).strip("-")
+    return slug or "episodio"
+
+
+def normalize_effects(content: str) -> tuple[str, list[dict[str, str]]]:
+    warnings: list[dict[str, str]] = []
+    pattern = re.compile(r"\((ES|ZI|ZO|PA-I|PA-D|TI-A|TI-B|PP)([0-9]+(?:\.[0-9]+)?)([^()]*)\)")
+
+    def replace(match: re.Match[str]) -> str:
+        before = match.group(0)
+        after = f"({match.group(1)}*{match.group(2)}{match.group(3)})"
+        warnings.append({"code": "W_LEGACY_EFFECT_SYNTAX", "before": before, "after": after})
+        return after
+
+    return pattern.sub(replace, content), warnings
+
+
+def normalize(data: dict) -> tuple[dict, list[dict[str, str]]]:
+    if data.get("schemaVersion") == "1.0":
+        return data, []
+    title = str(data.get("title", "")).strip()
+    content = str(data.get("content", "")).replace("\r\n", "\n").replace("\r", "\n").lstrip("\ufeff")
+    content, warnings = normalize_effects(content)
+    episode_id = slugify(title)
+    seed = int.from_bytes(hashlib.sha256(episode_id.encode()).digest()[:4], "big") & 0x7FFFFFFF
+    source: dict[str, str] = {"importedFrom": "MAAS legacy JSON"}
+    if data.get("url"):
+        source["url"] = str(data["url"])
+    if data.get("sendDate"):
+        warnings.append({"code": "W_LEGACY_DATE_TIMEZONE", "value": str(data["sendDate"])})
+    status = {"procesar": "ready", "procesado": "published"}.get(str(data.get("status", "")).lower(), "draft")
+    warnings.insert(0, {"code": "W_LEGACY_INPUT", "value": "Contrato histórico convertido a 1.0"})
+    return {
+        "schemaVersion": "1.0",
+        "episodeId": episode_id,
+        "title": title or episode_id,
+        "language": "es-MX",
+        "status": status,
+        "seed": seed,
+        "source": source,
+        "content": content,
+    }, warnings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    try:
+        data = json.loads(args.input.read_text(encoding="utf-8-sig"))
+        normalized, warnings = normalize(data)
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError) as exc:
+        print(f"E_JSON_INVALID: {exc}", file=sys.stderr)
+        return 1
+    payload = json.dumps(normalized, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload, encoding="utf-8", newline="\n")
+    else:
+        sys.stdout.write(payload)
+    for warning in warnings:
+        print(json.dumps(warning, ensure_ascii=False), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/habilidades/crear-repositorio-maas-html/SKILL.md
+++ b/habilidades/crear-repositorio-maas-html/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: crear-repositorio-maas-html
+description: Crea desde cero un repositorio MAAS HTML con React, TypeScript, Vite, PixiJS, compilador Python, schemas, pruebas y CI. Usar para iniciar la migración completa o reconstruir el starter sin depender del renderer de video legado.
+---
+
+# Crear repositorio MAAS HTML
+
+1. Ejecutar `scripts/check_prerequisites.py`.
+2. Leer `references/architecture.md` y confirmar que el destino está vacío.
+3. Ejecutar `scripts/scaffold_repository.py DESTINO` para copiar el starter, schemas y herramientas de las skills hermanas.
+4. Ejecutar en el nuevo repositorio `python -m unittest discover tests/python`, `npm install`, `npm test` y `npm run build`.
+5. Invocar, en orden: `$definir-contratos-maas`, `$migrar-insumos-maas`, `$compilar-guion-maas`, `$reproducir-efectos-maas`, `$renderizar-escenas-maas`, `$sincronizar-audio-maas`, `$empaquetar-episodio-maas` y `$auditar-paridad-maas`.
+
+## Guardas
+
+- No inicializar sobre un directorio no vacío sin `--force`; aun con `--force`, no sobrescribir archivos existentes.
+- No copiar outputs MP4, cachés, secretos ni assets sin licencia.
+- Mantener Python como herramienta de build y TypeScript como runtime del navegador.
+- Usar `legacy-v1` hasta que la auditoría apruebe `canonical-v1`.

--- a/habilidades/crear-repositorio-maas-html/agents/openai.yaml
+++ b/habilidades/crear-repositorio-maas-html/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Crear repositorio MAAS HTML"
+  short_description: "Inicializa el reproductor HTML completo"
+  default_prompt: "Usa $crear-repositorio-maas-html para crear desde cero un repositorio MAAS HTML."

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/.github/workflows/ci.yml
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+on:
+  push:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: {python-version: "3.12"}
+      - uses: actions/setup-node@v4
+        with: {node-version: "22", cache: npm}
+      - run: python -m pip install -e .
+      - run: python -m unittest discover tests/python
+      - run: npm install
+      - run: npm test
+      - run: npm run build

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/.gitignore
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+.vite/
+__pycache__/
+*.pyc
+.venv/
+.env
+build-report.json

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/index.html
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:; media-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self'" />
+    <title>MAAS HTML Player</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/package.json
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "maas-html-player",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "test": "vitest run",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "pixi.js": "^8",
+    "react": "^19",
+    "react-dom": "^19"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@vitejs/plugin-react": ">=4 <6",
+    "typescript": "^5",
+    "vite": ">=6 <8",
+    "vitest": ">=3 <5"
+  }
+}

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/public/episodes/demo/episode.manifest.json
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/public/episodes/demo/episode.manifest.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1.0",
+  "episodeId": "demo",
+  "title": "Episodio de demostración",
+  "profile": "legacy-v1",
+  "durationMs": 4000,
+  "timeline": [
+    {
+      "id": "cue-0001",
+      "type": "dialogue",
+      "startMs": 0,
+      "durationMs": 4000,
+      "text": "MAAS ahora vive en HTML.",
+      "speaker": "Narrador",
+      "speakerPosition": "izquierda",
+      "effect": {"code": "ZI", "intensity": 1.2, "target": null, "tremor": true}
+    }
+  ]
+}

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/pyproject.toml
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "maas-html-builder"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+maas = "maas_builder.cli:main"
+
+[tool.setuptools]
+package-dir = {"" = "tools"}
+
+[tool.setuptools.packages.find]
+where = ["tools"]

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/src/audio/AudioEngine.ts
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/src/audio/AudioEngine.ts
@@ -1,0 +1,59 @@
+export type AudioBus = "voice" | "sfx" | "music";
+
+export class AudioEngine {
+  private context: AudioContext | null = null;
+  private master: GainNode | null = null;
+  private readonly buses = new Map<AudioBus, GainNode>();
+  private readonly active = new Set<AudioBufferSourceNode>();
+
+  async unlock(): Promise<void> {
+    if (!this.context) {
+      this.context = new AudioContext({ sampleRate: 44_100 });
+      this.master = this.context.createGain();
+      this.master.connect(this.context.destination);
+      for (const name of ["voice", "sfx", "music"] as const) {
+        const gain = this.context.createGain();
+        gain.connect(this.master);
+        this.buses.set(name, gain);
+      }
+    }
+    if (this.context.state !== "running") await this.context.resume();
+  }
+
+  async decode(bytes: ArrayBuffer): Promise<AudioBuffer> {
+    if (!this.context) throw new Error("Audio bloqueado: llama unlock() desde un gesto de usuario");
+    return this.context.decodeAudioData(bytes.slice(0));
+  }
+
+  schedule(buffer: AudioBuffer, bus: AudioBus, startAt: number, offset = 0, gain = 1): AudioBufferSourceNode {
+    if (!this.context) throw new Error("AudioContext no inicializado");
+    const source = this.context.createBufferSource();
+    const cueGain = this.context.createGain();
+    cueGain.gain.value = gain;
+    source.buffer = buffer;
+    source.connect(cueGain).connect(this.buses.get(bus)!);
+    source.start(startAt, offset);
+    this.active.add(source);
+    source.addEventListener("ended", () => this.active.delete(source), { once: true });
+    return source;
+  }
+
+  stopAll(): void {
+    for (const source of this.active) {
+      try { source.stop(); } catch { /* ya terminó */ }
+    }
+    this.active.clear();
+  }
+
+  setMasterGain(value: number): void {
+    if (this.master) this.master.gain.value = Math.max(0, Math.min(1, value));
+  }
+
+  async close(): Promise<void> {
+    this.stopAll();
+    await this.context?.close();
+    this.context = null;
+    this.master = null;
+    this.buses.clear();
+  }
+}

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/src/main.tsx
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/src/main.tsx
@@ -1,0 +1,5 @@
+import { mountEpisodePlayer } from "./player";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Falta #root");
+mountEpisodePlayer(root, "/episodes/demo/episode.manifest.json", { orientation: "auto", autoplay: false, reducedMotion: "system" });

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/src/player.tsx
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/src/player.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { App } from "./ui/App";
+import "./styles.css";
+
+export interface PlayerOptions {
+  orientation?: "landscape" | "portrait" | "auto";
+  autoplay?: boolean;
+  reducedMotion?: "system" | "on" | "off";
+}
+
+export function mountEpisodePlayer(element: HTMLElement, manifestUrl: string, options: PlayerOptions = {}): () => void {
+  const root: Root = createRoot(element);
+  root.render(<StrictMode><App manifestUrl={manifestUrl} options={options} /></StrictMode>);
+  return () => root.unmount();
+}

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/src/renderer/MaasStage.ts
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/src/renderer/MaasStage.ts
@@ -1,0 +1,60 @@
+import { Application, Assets, Container, Sprite, Text, TextStyle } from "pixi.js";
+import type { TimelineCue } from "../types";
+import { legacyCameraTransform } from "./effectMath";
+
+export class MaasStage {
+  private readonly app = new Application();
+  private readonly viewport = new Container();
+  private readonly camera = new Container();
+  private cue?: TimelineCue;
+
+  async init(host: HTMLElement): Promise<void> {
+    await this.app.init({ background: "#f7f5ef", resizeTo: host, antialias: true });
+    host.appendChild(this.app.canvas);
+    this.viewport.addChild(this.camera);
+    this.app.stage.addChild(this.viewport);
+    this.resize(host.clientWidth, host.clientHeight);
+  }
+
+  async show(cue: TimelineCue): Promise<void> {
+    this.cue = cue;
+    this.camera.removeChildren().forEach((child) => child.destroy());
+    if (cue.backgroundUrl) {
+      const texture = await Assets.load(cue.backgroundUrl);
+      const background = new Sprite(texture);
+      background.width = 1920;
+      background.height = 1080;
+      this.camera.addChild(background);
+    }
+    if (cue.spriteUrl) {
+      const texture = await Assets.load(cue.spriteUrl);
+      const sprite = new Sprite(texture);
+      sprite.width = 854;
+      sprite.height = 854;
+      sprite.position.set(cue.speakerPosition === "derecha" ? 968 : 300, 308);
+      this.camera.addChild(sprite);
+    }
+    const visualText = new Text({ text: cue.text ?? "", style: new TextStyle({ fontFamily: "Nanum Gothic, sans-serif", fontSize: 80, fill: "#111", wordWrap: true, wordWrapWidth: 500 }) });
+    visualText.position.set(cue.speakerPosition === "derecha" ? 348 : 1054, cue.speakerPosition === "derecha" ? 70 : 98);
+    this.camera.addChild(visualText);
+    this.camera.pivot.set(960, 540);
+    this.camera.position.set(960, 540);
+  }
+
+  update(elapsedMs: number): void {
+    if (!this.cue?.effect) return;
+    const value = legacyCameraTransform(this.cue.effect.code, this.cue.effect.intensity, this.cue.speakerPosition ?? "izquierda", elapsedMs / 1000);
+    this.camera.scale.set(value.scale);
+    this.camera.position.set(960 + value.x * 1920, 540 + value.y * 1080);
+  }
+
+  resize(width: number, height: number): void {
+    const scale = Math.min(width / 1920, height / 1080);
+    this.viewport.scale.set(scale);
+    this.viewport.position.set((width - 1920 * scale) / 2, (height - 1080 * scale) / 2);
+  }
+
+  destroy(): void {
+    this.app.destroy(true, { children: true, texture: false, textureSource: false });
+  }
+}

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/src/renderer/effectMath.ts
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/src/renderer/effectMath.ts
@@ -1,0 +1,16 @@
+import type { EffectCode } from "../types";
+
+export function legacyCameraTransform(code: EffectCode, intensity: number, position: "izquierda" | "derecha", seconds: number) {
+  const i = intensity > 0 ? intensity : 1;
+  const b = 0.05;
+  const sign = position === "izquierda" ? -1 : 1;
+  if (code === "ES") return { scale: 1, x: 0, y: 0 };
+  if (code === "ZI" || code === "ZO") {
+    const scale = 1 + (code === "ZI" ? 1 : -1) * b * i * seconds;
+    if (scale <= 0) throw new Error("E_EFFECT: escala no positiva");
+    return { scale, x: sign * b * i * seconds / 2, y: 0 };
+  }
+  if (code === "PA-I" || code === "PA-D") return { scale: 1 + b * i * seconds / 2, x: sign * b * i * seconds / 4, y: 0 };
+  if (code === "TI-A" || code === "TI-B") return { scale: 1, x: 0, y: (code === "TI-A" ? 1 : -1) * b * i * seconds };
+  return { scale: 1 + b * i * seconds, x: 0, y: 0 };
+}

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/src/styles.css
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/src/styles.css
@@ -1,0 +1,13 @@
+:root { font-family: "Nanum Gothic", system-ui, sans-serif; color: #171717; background: #eeeae0; }
+* { box-sizing: border-box; }
+body { margin: 0; min-width: 320px; }
+button, input { font: inherit; }
+button:focus-visible, input:focus-visible { outline: 3px solid #005fcc; outline-offset: 3px; }
+.player { width: min(100%, 1200px); margin: auto; padding: 1rem; }
+.stage { width: 100%; aspect-ratio: 16 / 9; background: #000; overflow: hidden; }
+.player[data-orientation="portrait"] .stage { aspect-ratio: 9 / 16; max-height: 80vh; }
+.caption { min-height: 3rem; font-size: 1.2rem; }
+.controls { display: flex; gap: 1rem; align-items: center; }
+.controls input { flex: 1; }
+@media (prefers-reduced-motion: reduce) { .player { scroll-behavior: auto; } }
+@media (orientation: portrait) { .player[data-orientation="auto"] .stage { aspect-ratio: 9 / 16; max-height: 80vh; } }

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/src/types.ts
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/src/types.ts
@@ -1,0 +1,30 @@
+export type EffectCode = "ES" | "ZI" | "ZO" | "PA-I" | "PA-D" | "TI-A" | "TI-B" | "PP";
+
+export interface EffectSpec {
+  code: EffectCode;
+  intensity: number;
+  target?: string | null;
+  tremor: boolean;
+}
+
+export interface TimelineCue {
+  id: string;
+  type: "scene" | "dialogue" | "sfx" | "transition" | "advice" | "ending";
+  startMs: number;
+  durationMs: number;
+  text?: string;
+  speaker?: string;
+  effect?: EffectSpec;
+  backgroundUrl?: string;
+  spriteUrl?: string;
+  speakerPosition?: "izquierda" | "derecha";
+}
+
+export interface EpisodeManifest {
+  schemaVersion: "1.0";
+  episodeId: string;
+  title: string;
+  profile: "legacy-v1" | "canonical-v1";
+  durationMs: number;
+  timeline: TimelineCue[];
+}

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/src/ui/App.tsx
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/src/ui/App.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { EpisodeManifest, TimelineCue } from "../types";
+import type { PlayerOptions } from "../player";
+import { MaasStage } from "../renderer/MaasStage";
+
+export function App({ manifestUrl, options }: { manifestUrl: string; options: PlayerOptions }) {
+  const host = useRef<HTMLDivElement>(null);
+  const stage = useRef<MaasStage | null>(null);
+  const positionRef = useRef(0);
+  const [manifest, setManifest] = useState<EpisodeManifest>();
+  const [started, setStarted] = useState(false);
+  const [playing, setPlaying] = useState(false);
+  const [position, setPosition] = useState(0);
+  const active = useMemo<TimelineCue | undefined>(() => manifest?.timeline.find((cue) => cue.type !== "scene" && position >= cue.startMs && position < cue.startMs + cue.durationMs), [manifest, position]);
+
+  useEffect(() => { fetch(manifestUrl).then((response) => { if (!response.ok) throw new Error(`Manifest ${response.status}`); return response.json(); }).then(setManifest); }, [manifestUrl]);
+  useEffect(() => {
+    if (!host.current) return;
+    const value = new MaasStage();
+    stage.current = value;
+    void value.init(host.current);
+    const observer = new ResizeObserver(([entry]) => value.resize(entry.contentRect.width, entry.contentRect.height));
+    observer.observe(host.current);
+    return () => { observer.disconnect(); value.destroy(); };
+  }, []);
+  useEffect(() => { if (active) void stage.current?.show(active); }, [active?.id]);
+  useEffect(() => {
+    if (!playing || !manifest) return;
+    let frame = 0;
+    let last = performance.now();
+    const tick = (now: number) => {
+      const delta = now - last;
+      last = now;
+      setPosition((old) => {
+        const next = Math.min(manifest.durationMs, old + delta);
+        positionRef.current = next;
+        return next;
+      });
+      stage.current?.update(active ? positionRef.current - active.startMs : 0);
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, [playing, manifest, active?.id]);
+
+  if (!manifest) return <p role="status">Cargando episodio…</p>;
+  return <main className="player" data-orientation={options.orientation ?? "auto"}>
+    <h1>{manifest.title}</h1>
+    <div className="stage" ref={host} aria-hidden="true" />
+    <p className="caption" aria-live="polite"><strong>{active?.speaker}</strong>{active?.speaker ? ": " : ""}{active?.text}</p>
+    {!started ? <button onClick={() => { setStarted(true); setPlaying(options.autoplay ?? false); }}>Iniciar episodio</button> : <div className="controls">
+      <button onClick={() => setPlaying((value) => !value)}>{playing ? "Pausar" : "Reproducir"}</button>
+      <input aria-label="Progreso" type="range" min={0} max={manifest.durationMs} value={position} onChange={(event) => { const next = Number(event.target.value); positionRef.current = next; setPosition(next); }} />
+    </div>}
+  </main>;
+}

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/tests/python/test_starter.py
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/tests/python/test_starter.py
@@ -1,0 +1,15 @@
+import json
+import unittest
+from pathlib import Path
+
+
+class StarterTest(unittest.TestCase):
+    def test_demo_manifest_has_timeline(self):
+        root = Path(__file__).resolve().parents[2]
+        data = json.loads((root / "public/episodes/demo/episode.manifest.json").read_text(encoding="utf-8"))
+        self.assertEqual(data["schemaVersion"], "1.0")
+        self.assertGreater(len(data["timeline"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/tests/typescript/effectMath.test.ts
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/tests/typescript/effectMath.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { legacyCameraTransform } from "../../src/renderer/effectMath";
+
+describe("legacyCameraTransform", () => {
+  it("reproduce ZI a los dos segundos", () => {
+    expect(legacyCameraTransform("ZI", 1, "izquierda", 2)).toEqual({ scale: 1.1, x: -0.05, y: 0 });
+  });
+  it("mantiene PA-I y PA-D idénticos en legacy", () => {
+    expect(legacyCameraTransform("PA-I", 1.2, "derecha", 5)).toEqual(legacyCameraTransform("PA-D", 1.2, "derecha", 5));
+  });
+});

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/tools/maas_builder/__init__.py
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/tools/maas_builder/__init__.py
@@ -1,0 +1,3 @@
+"""CLI de build para MAAS HTML."""
+
+__version__ = "0.1.0"

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/tools/maas_builder/__main__.py
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/tools/maas_builder/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+raise SystemExit(main())

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/tools/maas_builder/cli.py
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/tools/maas_builder/cli.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def run(script: Path, *args: object) -> int:
+    return subprocess.call([sys.executable, str(script), *(str(value) for value in args)])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="maas")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    validate = sub.add_parser("validate")
+    validate.add_argument("input", type=Path)
+    validate.add_argument("--mode", choices=("strict", "legacy"), default="strict")
+
+    compile_command = sub.add_parser("compile")
+    compile_command.add_argument("input", type=Path)
+    compile_command.add_argument("--profile", choices=("legacy-v1", "canonical-v1"), default="legacy-v1")
+    compile_command.add_argument("--output", type=Path, required=True)
+    compile_command.add_argument("--character-map", type=Path)
+
+    assets = sub.add_parser("assets")
+    assets_sub = assets.add_subparsers(dest="assets_command", required=True)
+    scan = assets_sub.add_parser("scan")
+    scan.add_argument("root", type=Path)
+    scan.add_argument("--output", type=Path, required=True)
+    scan.add_argument("--overrides", type=Path)
+
+    build = sub.add_parser("build")
+    build.add_argument("input", type=Path)
+    build.add_argument("--output", type=Path, required=True)
+    build.add_argument("--player-dist", type=Path, default=Path("web-dist"))
+    build.add_argument("--profile", choices=("legacy-v1", "canonical-v1"), default="legacy-v1")
+    build.add_argument("--character-map", type=Path)
+
+    verify = sub.add_parser("verify")
+    verify.add_argument("target", type=Path)
+    verify.add_argument("--publication", action="store_true")
+
+    args = parser.parse_args()
+    repo = Path(__file__).resolve().parents[2]
+    scripts = repo / "tools" / "scripts"
+    if args.command == "validate":
+        return run(scripts / "validate_episode.py", args.input, "--mode", args.mode, "--pretty")
+    if args.command == "compile":
+        command: list[object] = [args.input, "--profile", args.profile, "--output", args.output]
+        if args.character_map:
+            command += ["--character-map", args.character_map]
+        return run(scripts / "compile_episode.py", *command)
+    if args.command == "assets":
+        command = [args.root, "--output", args.output]
+        if args.overrides:
+            command += ["--overrides", args.overrides]
+        return run(scripts / "build_asset_manifest.py", *command)
+    if args.command == "verify":
+        if args.target.is_file():
+            try:
+                manifest = json.loads(args.target.read_text(encoding="utf-8-sig"))
+                timeline = manifest["timeline"]
+                ordered = timeline == sorted(timeline, key=lambda cue: (cue["startMs"], cue["id"]))
+                valid = manifest.get("schemaVersion") == "1.0" and isinstance(manifest.get("durationMs"), int) and ordered
+            except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError):
+                valid = False
+            print(json.dumps({"valid": valid, "target": str(args.target)}, ensure_ascii=False))
+            return 0 if valid else 1
+        command = [args.target]
+        if args.publication:
+            command.append("--publication")
+        return run(scripts / "verify_bundle.py", *command)
+    if args.command == "build":
+        with tempfile.TemporaryDirectory(prefix="maas-build-") as temporary:
+            manifest = Path(temporary) / "episode.manifest.json"
+            compile_args: list[object] = [args.input, "--profile", args.profile, "--output", manifest]
+            if args.character_map:
+                compile_args += ["--character-map", args.character_map]
+            code = run(scripts / "compile_episode.py", *compile_args)
+            if code:
+                return code
+            return run(scripts / "build_episode.py", manifest, "--player-dist", args.player_dist, "--output", args.output)
+    return 2

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/tsconfig.json
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "tests/typescript", "vite.config.ts"]
+}

--- a/habilidades/crear-repositorio-maas-html/assets/starter-repository/vite.config.ts
+++ b/habilidades/crear-repositorio-maas-html/assets/starter-repository/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  build: { sourcemap: true, assetsDir: "assets" },
+});

--- a/habilidades/crear-repositorio-maas-html/references/architecture.md
+++ b/habilidades/crear-repositorio-maas-html/references/architecture.md
@@ -1,0 +1,57 @@
+# Arquitectura del repositorio nuevo
+
+## Índice
+
+1. Capas
+2. Estructura
+3. Flujo
+4. Decisiones
+
+## 1. Capas
+
+- `content/`: fuentes editoriales inmutables.
+- `schemas/`: contratos JSON 2020-12.
+- `tools/maas_builder/`: CLI Python y automatización de build.
+- `tools/scripts/`: implementaciones deterministas aportadas por las skills.
+- `src/`: shell React, renderer PixiJS, timeline y Web Audio.
+- `public/assets/`: assets autorizados y hasheados.
+- `dist/`: salida generada, nunca fuente.
+- `tests/`: unitarias Python/TypeScript, golden y E2E.
+
+## 2. Estructura
+
+```text
+maas-html/
+├── content/episodes/
+├── schemas/
+├── public/assets/
+├── src/{audio,renderer}/
+├── tools/{maas_builder,scripts}/
+├── tests/{python,typescript,e2e,golden}/
+├── package.json
+├── pyproject.toml
+└── vite.config.ts
+```
+
+## 3. Flujo
+
+```text
+episode-source.json
+  → validate
+  → compile + asset manifest
+  → episode.manifest.json
+  → Vite static build
+  → browser validation
+  → PixiJS + Web Audio
+  → parity report
+```
+
+El renderer nunca parsea el guion libre. El compilador nunca genera video. La publicación nunca obtiene secretos del navegador.
+
+## 4. Decisiones
+
+- React controla UI/estado; PixiJS dibuja.
+- Coordenadas lógicas 1920×1080; salida portrait mediante composición legada rotada.
+- JSON Schema es autoridad de contratos.
+- Build reproducible con seed, claves ordenadas y assets por SHA-256.
+- Carpeta estática por episodio con assets compartidos.

--- a/habilidades/crear-repositorio-maas-html/scripts/check_prerequisites.py
+++ b/habilidades/crear-repositorio-maas-html/scripts/check_prerequisites.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Comprueba herramientas requeridas sin instalar ni modificar el sistema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import shutil
+import subprocess
+import sys
+
+
+def version(command: list[str]) -> str | None:
+    if not shutil.which(command[0]):
+        return None
+    try:
+        result = subprocess.run(command, check=True, capture_output=True, text=True, timeout=10)
+        return result.stdout.strip() or result.stderr.strip()
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+    report = {
+        "python": platform.python_version(),
+        "pythonOk": sys.version_info >= (3, 11),
+        "node": version(["node", "--version"]),
+        "npm": version(["npm", "--version"]),
+        "git": version(["git", "--version"]),
+        "ffprobeOptional": version(["ffprobe", "-version"]),
+    }
+    report["valid"] = bool(report["pythonOk"] and report["node"] and report["npm"] and report["git"])
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0 if report["valid"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/habilidades/crear-repositorio-maas-html/scripts/scaffold_repository.py
+++ b/habilidades/crear-repositorio-maas-html/scripts/scaffold_repository.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Copia el starter y herramientas hermanas a un directorio nuevo."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+def copy_tree_without_overwrite(source: Path, destination: Path) -> None:
+    for path in source.rglob("*"):
+        relative = path.relative_to(source)
+        target = destination / relative
+        if path.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+        elif target.exists():
+            raise FileExistsError(f"No se sobrescribe: {target}")
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(path, target)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("destination", type=Path)
+    parser.add_argument("--force", action="store_true", help="Permite un directorio existente, sin sobrescribir archivos")
+    args = parser.parse_args()
+    skill = Path(__file__).resolve().parents[1]
+    skills_root = skill.parent
+    destination = args.destination.resolve()
+    if destination.exists() and any(destination.iterdir()) and not args.force:
+        print(f"Destino no vacío: {destination}")
+        return 1
+    destination.mkdir(parents=True, exist_ok=True)
+    try:
+        copy_tree_without_overwrite(skill / "assets" / "starter-repository", destination)
+        schemas = skills_root / "definir-contratos-maas" / "assets" / "schemas"
+        copy_tree_without_overwrite(schemas, destination / "schemas")
+        scripts = {
+            "validate_episode.py": skills_root / "definir-contratos-maas" / "scripts" / "validate_episode.py",
+            "normalize_legacy_input.py": skills_root / "compilar-guion-maas" / "scripts" / "normalize_legacy_input.py",
+            "compile_episode.py": skills_root / "compilar-guion-maas" / "scripts" / "compile_episode.py",
+            "build_asset_manifest.py": skills_root / "migrar-insumos-maas" / "scripts" / "build_asset_manifest.py",
+            "probe_media.py": skills_root / "migrar-insumos-maas" / "scripts" / "probe_media.py",
+            "audit_assets.py": skills_root / "migrar-insumos-maas" / "scripts" / "audit_assets.py",
+            "legacy_effect_math.py": skills_root / "reproducir-efectos-maas" / "scripts" / "legacy_effect_math.py",
+            "build_audio_cues.py": skills_root / "sincronizar-audio-maas" / "scripts" / "build_audio_cues.py",
+            "build_episode.py": skills_root / "empaquetar-episodio-maas" / "scripts" / "build_episode.py",
+            "verify_bundle.py": skills_root / "empaquetar-episodio-maas" / "scripts" / "verify_bundle.py",
+            "compare_frames.py": skills_root / "auditar-paridad-maas" / "scripts" / "compare_frames.py",
+            "compare_timelines.py": skills_root / "auditar-paridad-maas" / "scripts" / "compare_timelines.py",
+            "generate_audit_report.py": skills_root / "auditar-paridad-maas" / "scripts" / "generate_audit_report.py",
+        }
+        target_scripts = destination / "tools" / "scripts"
+        target_scripts.mkdir(parents=True, exist_ok=True)
+        for name, source in scripts.items():
+            target = target_scripts / name
+            if target.exists():
+                raise FileExistsError(f"No se sobrescribe: {target}")
+            shutil.copy2(source, target)
+    except (OSError, FileExistsError) as exc:
+        print(str(exc))
+        return 1
+    print(destination)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/habilidades/definir-contratos-maas/SKILL.md
+++ b/habilidades/definir-contratos-maas/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: definir-contratos-maas
+description: Define, documenta y valida los contratos versionados de entrada, assets y manifiestos de MAAS HTML. Usar al crear o cambiar episode-source.json, asset-manifest.json, episode.manifest.json, la gramática textual de guiones o los diagnósticos del compilador.
+---
+
+# Definir contratos MAAS
+
+1. Leer `references/input-contract.md` y `references/script-grammar.md` antes de aceptar un input.
+2. Tratar los schemas de `assets/schemas/` como fuente de verdad; no inferir campos nuevos desde ejemplos.
+3. Ejecutar `scripts/validate_episode.py INPUT --mode strict` para inputs nuevos y `--mode legacy` para importar JSON históricos.
+4. Corregir errores antes de compilar. Conservar advertencias en el `build-report.json`.
+5. Leer `references/canonical-manifest.md` al producir o consumir una timeline.
+6. Usar exclusivamente los códigos de `references/validation-errors.md`.
+
+## Invariantes
+
+- Mantener UTF-8, tiempos enteros en milisegundos y rutas relativas con `/`.
+- No modificar el archivo fuente durante validación o compilación.
+- No resolver silenciosamente personajes, lugares, emociones, assets ni efectos desconocidos.
+- Conservar `declaredDurationMs` y calcular `resolvedDurationMs` por separado.
+- Escapar el contenido al mostrarlo; nunca tratar `content` como HTML.
+
+## Salida mínima
+
+Entregar diagnósticos ordenados por línea y columna con `code`, `severity`, `message` y `suggestion`. Un error produce exit code 1; solo advertencias producen exit code 0.

--- a/habilidades/definir-contratos-maas/agents/openai.yaml
+++ b/habilidades/definir-contratos-maas/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Definir contratos MAAS"
+  short_description: "Define y valida contratos de episodios"
+  default_prompt: "Usa $definir-contratos-maas para validar el contrato de un episodio MAAS."

--- a/habilidades/definir-contratos-maas/assets/schemas/asset-manifest.schema.json
+++ b/habilidades/definir-contratos-maas/assets/schemas/asset-manifest.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://maas.local/schemas/asset-manifest.schema.json",
+  "title": "MAAS asset manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "generatedAt", "assets"],
+  "properties": {
+    "schemaVersion": {"const": "1.0"},
+    "generatedAt": {"type": "string", "format": "date-time"},
+    "assets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "type", "path", "sha256", "mimeType", "allowedForPublish"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
+          "type": {"enum": ["background", "sprite", "transition", "font", "voice", "sfx", "music", "ending", "other"]},
+          "path": {"type": "string", "pattern": "^(?!/)(?!.*\\.\\./).+$"},
+          "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+          "mimeType": {"type": "string", "minLength": 1},
+          "width": {"type": ["integer", "null"], "minimum": 1},
+          "height": {"type": ["integer", "null"], "minimum": 1},
+          "durationMs": {"type": ["integer", "null"], "minimum": 0},
+          "character": {"type": ["string", "null"]},
+          "emotion": {"type": ["string", "null"]},
+          "gaze": {"enum": ["left", "right", "front", null]},
+          "place": {"type": ["string", "null"]},
+          "orientation": {"enum": ["landscape", "portrait", "both", null]},
+          "aliases": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+          "source": {"type": ["string", "null"]},
+          "author": {"type": ["string", "null"]},
+          "license": {"type": ["string", "null"]},
+          "allowedForPublish": {"type": "boolean"}
+        }
+      }
+    }
+  }
+}

--- a/habilidades/definir-contratos-maas/assets/schemas/episode-manifest.schema.json
+++ b/habilidades/definir-contratos-maas/assets/schemas/episode-manifest.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://maas.local/schemas/episode-manifest.schema.json",
+  "title": "MAAS compiled episode",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "episodeId", "title", "language", "status", "seed", "profile", "orientations", "characters", "assets", "audioPolicy", "timeline", "durationMs", "warnings"],
+  "properties": {
+    "schemaVersion": {"const": "1.0"},
+    "episodeId": {"type": "string"},
+    "title": {"type": "string"},
+    "language": {"type": "string"},
+    "status": {"enum": ["draft", "ready", "published"]},
+    "seed": {"type": "integer", "minimum": 0},
+    "profile": {"enum": ["legacy-v1", "canonical-v1"]},
+    "orientations": {"type": "array", "items": {"enum": ["landscape", "portrait"]}, "minItems": 1, "uniqueItems": true},
+    "characters": {"type": "object", "additionalProperties": {"type": "string"}},
+    "assets": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+    "audioPolicy": {"type": "object"},
+    "timeline": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "type", "startMs", "durationMs"],
+        "properties": {
+          "id": {"type": "string"},
+          "type": {"enum": ["scene", "dialogue", "sfx", "transition", "advice", "ending"]},
+          "startMs": {"type": "integer", "minimum": 0},
+          "durationMs": {"type": "integer", "minimum": 0}
+        }
+      }
+    },
+    "durationMs": {"type": "integer", "minimum": 0},
+    "warnings": {"type": "array", "items": {"type": "object"}}
+  }
+}

--- a/habilidades/definir-contratos-maas/assets/schemas/episode-source.schema.json
+++ b/habilidades/definir-contratos-maas/assets/schemas/episode-source.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://maas.local/schemas/episode-source.schema.json",
+  "title": "MAAS episode source",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "episodeId", "title", "language", "status", "content"],
+  "properties": {
+    "schemaVersion": {"const": "1.0"},
+    "episodeId": {"type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$", "maxLength": 100},
+    "title": {"type": "string", "minLength": 1, "maxLength": 200},
+    "language": {"type": "string", "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"},
+    "status": {"enum": ["draft", "ready", "published"]},
+    "seed": {"type": "integer", "minimum": 0, "maximum": 2147483647},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {"type": "string", "format": "uri"},
+        "createdAt": {"type": "string", "format": "date-time"},
+        "importedFrom": {"type": "string", "minLength": 1}
+      }
+    },
+    "content": {"type": "string", "minLength": 1}
+  }
+}

--- a/habilidades/definir-contratos-maas/references/canonical-manifest.md
+++ b/habilidades/definir-contratos-maas/references/canonical-manifest.md
@@ -1,0 +1,70 @@
+# Contrato de `episode.manifest.json`
+
+## Índice
+
+1. Raíz
+2. Timeline
+3. Efectos y audio
+4. Orden y determinismo
+
+## 1. Raíz
+
+El manifiesto contiene `schemaVersion`, `episodeId`, `title`, `language`, `status`, `seed`, `profile`, `orientations`, `characters`, `assets`, `audioPolicy`, `timeline`, `durationMs` y `warnings`.
+
+- `profile`: `legacy-v1` o `canonical-v1`.
+- `orientations`: subconjunto no vacío de `landscape`, `portrait`.
+- `assets`: IDs presentes en un manifiesto de assets validado.
+- `warnings`: diagnósticos que no impidieron compilar.
+
+## 2. Timeline
+
+Todos los cues comparten:
+
+```json
+{
+  "id": "cue-0001",
+  "type": "dialogue",
+  "startMs": 0,
+  "durationMs": 2400
+}
+```
+
+Tipos:
+
+- `scene`: lugar, orientación y rango que agrupa cues.
+- `dialogue`: speaker, texto, emoción, dirección actoral, sprite y efecto.
+- `sfx`: sound key, asset y efecto.
+- `transition`: texto, imagen, duración y audio.
+- `advice`: texto seleccionado por seed.
+- `ending`: asset por orientación.
+
+`startMs` es absoluto, entero y no negativo. Los cues narrativos no se solapan; las pistas de música sí pueden solaparse mediante `audioPolicy`.
+
+## 3. Efectos y audio
+
+```json
+{
+  "effect": {
+    "code": "ZI",
+    "intensity": 1.2,
+    "target": null,
+    "tremor": true
+  },
+  "audio": {
+    "assetId": "voice-cue-0001",
+    "gain": 1.0,
+    "fadeInMs": 0,
+    "fadeOutMs": 0
+  }
+}
+```
+
+Los assets ausentes se representan como error de compilación, no con una ruta vacía.
+
+## 4. Orden y determinismo
+
+- Ordenar cues por `startMs`, luego por `id`.
+- Numerar IDs según orden del input.
+- Serializar JSON con claves ordenadas y newline final.
+- Toda elección variable usa un PRNG documentado a partir de `seed`.
+- Mismo input, assets, perfil y versión producen el mismo SHA-256.

--- a/habilidades/definir-contratos-maas/references/input-contract.md
+++ b/habilidades/definir-contratos-maas/references/input-contract.md
@@ -1,0 +1,65 @@
+# Contrato de `episode-source.json`
+
+## Índice
+
+1. Formato estricto
+2. Adaptador legado
+3. Normalización
+4. Ejemplo completo
+
+## 1. Formato estricto
+
+El archivo debe ser JSON UTF-8 y cumplir `episode-source.schema.json`.
+
+| Campo | Tipo | Regla |
+|---|---|---|
+| `schemaVersion` | string | Constante `1.0`. |
+| `episodeId` | string | `^[a-z0-9]+(?:-[a-z0-9]+)*$`, máximo 100 caracteres. |
+| `title` | string | Entre 1 y 200 caracteres después de trim. |
+| `language` | string | Etiqueta BCP 47 básica, por ejemplo `es-MX`. |
+| `status` | enum | `draft`, `ready` o `published`. |
+| `seed` | integer | 0 a 2,147,483,647. Si falta, derivar de SHA-256 de `episodeId`. |
+| `source` | object | Opcional; `url`, `createdAt` e `importedFrom`. |
+| `content` | string | Guion no vacío descrito en `script-grammar.md`. |
+
+Campos adicionales están prohibidos para detectar errores tipográficos.
+
+## 2. Adaptador legado
+
+El modo `legacy` acepta `title`, `content`, `url`, `status` y `sendDate`.
+
+- `status=procesar` se mapea a `ready`.
+- `status=procesado` se mapea a `published`.
+- `sendDate=YYYYMMDDhhmmss` se convierte a ISO 8601 sin inventar zona horaria; se registra `W_LEGACY_DATE_TIMEZONE`.
+- `episodeId` se deriva del título mediante Unicode NFKD, eliminación de diacríticos y slug ASCII.
+- Un campo legado desconocido se conserva únicamente en el reporte de importación.
+
+El adaptador devuelve un documento nuevo; nunca renombra, borra o reescribe el original.
+
+## 3. Normalización
+
+- Decodificar estrictamente como UTF-8; no reemplazar bytes inválidos.
+- Convertir CRLF y CR a LF.
+- Eliminar BOM inicial.
+- Conservar texto y puntuación; no eliminar apóstrofes.
+- Permitir encabezados editoriales antes del primer personaje, pero emitir advertencia.
+- Usar `seed` para toda selección de transición, variante sonora o fallback aprobado.
+
+## 4. Ejemplo completo
+
+```json
+{
+  "schemaVersion": "1.0",
+  "episodeId": "episodio-28-libertad-financiera",
+  "title": "Libertad financiera",
+  "language": "es-MX",
+  "status": "ready",
+  "seed": 2801,
+  "source": {
+    "url": "https://example.test/documento",
+    "createdAt": "2025-04-05T08:20:55Z",
+    "importedFrom": "MAAS/Guiones/capitulos"
+  },
+  "content": "[Pato] (4 segundos | Intriga | Inclina la cabeza)\n¿Sabías la noticia? (ZI*1.2)\nOSD (Dum!) (PP Pato)\n\n**CAFETERÍA**"
+}
+```

--- a/habilidades/definir-contratos-maas/references/script-grammar.md
+++ b/habilidades/definir-contratos-maas/references/script-grammar.md
@@ -1,0 +1,65 @@
+# Gramática del guion
+
+## Índice
+
+1. EBNF
+2. Duraciones
+3. Diálogo y OSD
+4. Lugares y transiciones
+5. Efectos
+6. Compatibilidad legado
+
+## 1. EBNF
+
+```ebnf
+document      = { blank | transition | speech }, EOF ;
+speech        = header, newline, { blank | dialogue | osd }, place ;
+header        = "[", character, "]", ws, "(", duration, "|", emotion, "|", stage, ")" ;
+dialogue      = text, ws, camera ;
+osd           = "OSD", ws, "(", sound, ")", ws, camera ;
+place         = "**", place-name, "**" ;
+transition    = "---", transition-text, "---" ;
+camera        = "(", effect, [ "*", positive-number ], [ ws, target ], ")" ;
+effect        = "ES" | "ZI" | "ZO" | "PA-I" | "PA-D" | "TI-A" | "TI-B" | "PP" ;
+```
+
+Los delimitadores `|` del header son obligatorios. `character`, `emotion`, `stage`, `text`, `sound`, `target` y nombres no pueden quedar vacíos.
+
+## 2. Duraciones
+
+Se aceptan `N segundo`, `N segundos` y `MM:SS`. Se convierten a `declaredDurationMs`. En `legacy-v1`, si existe audio:
+
+```text
+resolvedDurationMs = max(2000, floor((audioMs + 200) / 1000) * 1000)
+```
+
+En `canonical-v1`:
+
+```text
+resolvedDurationMs = max(declaredDurationMs, audioMs + 200)
+```
+
+Si no hay audio, se usa la duración declarada. Nunca sobrescribir el valor declarado.
+
+## 3. Diálogo y OSD
+
+- Cada línea de diálogo requiere exactamente un camera token al final.
+- Paréntesis internos en el texto deben escaparse como `\(` y `\)` o reemplazarse por signos editoriales.
+- `OSD` crea un cue `sfx`; el texto entre el primer paréntesis es la clave sonora.
+- `OSD (...)` y `OSD (… )` representan silencio explícito, no ausencia de cue.
+- `Bip bip` se conserva semánticamente y se presenta como `%!&$# >:(` solo en el renderer legado.
+
+## 4. Lugares y transiciones
+
+- Cada bloque de intervenciones termina en un lugar.
+- El lugar se compara de forma Unicode case-insensitive contra `asset-manifest.json`.
+- Un lugar desconocido es error. No elegir un fondo al azar.
+- Una transición separa bloques y genera un cue propio; no pertenece al diálogo anterior.
+
+## 5. Efectos
+
+La intensidad predeterminada es `1.0` y debe ser mayor que cero. `PP` puede incluir objetivo: `(PP Pato)`. Otros efectos no admiten objetivo en modo estricto.
+
+## 6. Compatibilidad legado
+
+`ZO1.2`, `PA-D1.2` y equivalentes se normalizan a `ZO*1.2` y `PA-D*1.2` solo en modo legado, con `W_LEGACY_EFFECT_SYNTAX`. Múltiples OSD consecutivos no se eliminan: se conservan y se reportan para revisión.

--- a/habilidades/definir-contratos-maas/references/validation-errors.md
+++ b/habilidades/definir-contratos-maas/references/validation-errors.md
@@ -1,0 +1,54 @@
+# Códigos de validación
+
+## Errores
+
+| Código | Condición |
+|---|---|
+| `E_JSON_INVALID` | JSON ilegible o UTF-8 inválido. |
+| `E_SCHEMA` | Campo ausente, adicional o con tipo/formato inválido. |
+| `E_SCRIPT_HEADER` | Header incompleto o mal delimitado. |
+| `E_DURATION` | Duración inválida o no positiva. |
+| `E_DIALOGUE_CAMERA` | Diálogo sin camera token válido. |
+| `E_EFFECT` | Código, intensidad u objetivo inválido. |
+| `E_PLACE` | Lugar vacío, desconocido o ausente. |
+| `E_CHARACTER` | Personaje no resoluble. |
+| `E_EMOTION` | Emoción sin mapping o fallback explícito. |
+| `E_ASSET` | Asset ausente, corrupto o incompatible. |
+| `E_LICENSE` | Asset no autorizado para publicar. |
+| `E_TIMELINE` | Cue negativo, desordenado o con solapamiento ilegal. |
+| `E_SECRET` | Posible credencial dentro del bundle. |
+| `E_HTML_INJECTION` | Uso de una API que interpreta HTML sin escapar. |
+| `E_REMOTE_RUNTIME` | Dependencia o URL remota en una salida publicable. |
+
+## Advertencias
+
+| Código | Condición |
+|---|---|
+| `W_LEGACY_INPUT` | Se usó el adaptador de cinco campos históricos. |
+| `W_LEGACY_DATE_TIMEZONE` | Fecha histórica sin zona horaria. |
+| `W_LEGACY_EFFECT_SYNTAX` | Intensidad sin `*`. |
+| `W_EDITORIAL_PREFIX` | Texto anterior al primer header. |
+| `W_UNKNOWN_HEADER_DURATION` | Duración declarada sustituida por audio. |
+| `W_FALLBACK_EXPRESSION` | Se usó una expresión alternativa declarada. |
+| `W_UNUSED_STAGE_DIRECTION` | Dirección actoral preservada pero no animada. |
+| `W_CHARACTER_IDENTITY` | Alias conservado como ID en legacy sin catálogo. |
+| `W_EMOTION_HAPPY_FALLBACK` | Emoción desconocida convertida a happy en legacy. |
+| `W_TRAILING_DIALOGUE_METADATA` | Metadata apareció después del camera token. |
+| `W_MISSING_CAMERA_STATIC` | Línea legacy sin cámara recuperada como ES. |
+| `W_LEGACY_HEADER_PARENTHESES` | Header legacy tenía paréntesis extra. |
+| `W_ASSET_NAMING` | Nombre de asset histórico irregular. |
+| `W_LICENSE_UNKNOWN` | Licencia todavía no documentada. |
+| `W_DUPLICATE_CONTENT` | Dos IDs comparten el mismo SHA-256. |
+
+Formato:
+
+```json
+{
+  "code": "E_EFFECT",
+  "severity": "error",
+  "line": 12,
+  "column": 28,
+  "message": "La intensidad debe ser mayor que cero.",
+  "suggestion": "Usa (ZI*1.2)."
+}
+```

--- a/habilidades/definir-contratos-maas/scripts/validate_episode.py
+++ b/habilidades/definir-contratos-maas/scripts/validate_episode.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Valida el contenedor JSON y la gramática esencial de un episodio MAAS."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+STRICT_KEYS = {"schemaVersion", "episodeId", "title", "language", "status", "seed", "source", "content"}
+REQUIRED_KEYS = {"schemaVersion", "episodeId", "title", "language", "status", "content"}
+LEGACY_KEYS = {"title", "content", "url", "status", "sendDate"}
+HEADER_RE = re.compile(r"^\s*\[([^\]]+)\]\s*\(([^|]+)\|([^|]+)\|([^)]*)\)\s*$")
+PLACE_RE = re.compile(r"^\s*\*\*([^*]+)\*\*\s*$")
+TRANSITION_RE = re.compile(r"^\s*---(.+?)---\s*$")
+CAMERA_RE = re.compile(r"\((ES|ZI|ZO|PA-I|PA-D|TI-A|TI-B|PP)(?:\*([0-9]+(?:\.[0-9]+)?))?(?:\s+([^()]+))?\)\s*$")
+LEGACY_CAMERA_RE = re.compile(r"\((ES|ZI|ZO|PA-I|PA-D|TI-A|TI-B|PP)([0-9]+(?:\.[0-9]+)?)(?:\s+([^()]+))?\)\s*$")
+DURATION_RE = re.compile(r"^(?:([0-9]+)\s+segundos?|([0-9]{1,2}):([0-5][0-9]))$", re.IGNORECASE)
+EPISODE_ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+LANGUAGE_RE = re.compile(r"^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$")
+
+
+def diagnostic(code: str, severity: str, message: str, line: int = 0, column: int = 0, suggestion: str = "") -> dict[str, Any]:
+    return {"code": code, "severity": severity, "line": line, "column": column, "message": message, "suggestion": suggestion}
+
+
+def validate_container(data: Any, mode: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    if not isinstance(data, dict):
+        return [diagnostic("E_SCHEMA", "error", "La raíz debe ser un objeto JSON.")]
+    keys = set(data)
+    if mode == "legacy" and {"title", "content"}.issubset(keys) and "schemaVersion" not in keys:
+        out.append(diagnostic("W_LEGACY_INPUT", "warning", "Se detectó el contrato legado.", suggestion="Normaliza el archivo antes de publicarlo."))
+        unknown = keys - LEGACY_KEYS
+        if unknown:
+            out.append(diagnostic("E_SCHEMA", "error", f"Campos legados no permitidos: {sorted(unknown)}."))
+        if str(data.get("status", "")).lower() not in {"procesar", "procesado"}:
+            out.append(diagnostic("E_SCHEMA", "error", "status legado debe ser procesar o procesado."))
+        return out
+    missing = REQUIRED_KEYS - keys
+    unknown = keys - STRICT_KEYS
+    if missing:
+        out.append(diagnostic("E_SCHEMA", "error", f"Faltan campos: {sorted(missing)}."))
+    if unknown:
+        out.append(diagnostic("E_SCHEMA", "error", f"Campos no permitidos: {sorted(unknown)}."))
+    if data.get("schemaVersion") != "1.0":
+        out.append(diagnostic("E_SCHEMA", "error", "schemaVersion debe ser 1.0."))
+    if not EPISODE_ID_RE.fullmatch(str(data.get("episodeId", ""))):
+        out.append(diagnostic("E_SCHEMA", "error", "episodeId no es un slug válido."))
+    if not LANGUAGE_RE.fullmatch(str(data.get("language", ""))):
+        out.append(diagnostic("E_SCHEMA", "error", "language no parece una etiqueta BCP 47."))
+    if data.get("status") not in {"draft", "ready", "published"}:
+        out.append(diagnostic("E_SCHEMA", "error", "status debe ser draft, ready o published."))
+    seed = data.get("seed")
+    if seed is not None and (isinstance(seed, bool) or not isinstance(seed, int) or not 0 <= seed <= 2_147_483_647):
+        out.append(diagnostic("E_SCHEMA", "error", "seed debe ser entero entre 0 y 2147483647."))
+    return out
+
+
+def validate_script(content: str, mode: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    normalized = content.replace("\r\n", "\n").replace("\r", "\n").lstrip("\ufeff")
+    seen_header = False
+    block_has_header = False
+    block_has_place = False
+    for number, raw in enumerate(normalized.split("\n"), 1):
+        line = raw.strip()
+        if not line:
+            continue
+        header = HEADER_RE.fullmatch(raw)
+        if header:
+            if block_has_header and block_has_place:
+                block_has_header = False
+                block_has_place = False
+            seen_header = True
+            block_has_header = True
+            character, duration, emotion, stage = (x.strip() for x in header.groups())
+            if not all((character, emotion, stage)):
+                out.append(diagnostic("E_SCRIPT_HEADER", "error", "El header contiene un campo vacío.", number, 1))
+            if not DURATION_RE.fullmatch(duration):
+                out.append(diagnostic("E_DURATION", "error", f"Duración no válida: {duration}.", number, raw.find(duration) + 1, "Usa '4 segundos' o '00:04'."))
+            continue
+        if PLACE_RE.fullmatch(raw):
+            if not block_has_header:
+                out.append(diagnostic("E_PLACE", "error", "El lugar no cierra ningún bloque de intervención.", number, 1))
+            block_has_place = True
+            continue
+        if TRANSITION_RE.fullmatch(raw):
+            continue
+        if not seen_header:
+            out.append(diagnostic("W_EDITORIAL_PREFIX", "warning", "Texto editorial anterior al primer header.", number, 1))
+            continue
+        match = CAMERA_RE.search(raw)
+        legacy = LEGACY_CAMERA_RE.search(raw) if mode == "legacy" else None
+        if not match and legacy:
+            out.append(diagnostic("W_LEGACY_EFFECT_SYNTAX", "warning", f"Sintaxis histórica: {legacy.group(0)}.", number, legacy.start() + 1, "Inserta '*' antes de la intensidad."))
+            match = legacy
+        if not match:
+            out.append(diagnostic("E_DIALOGUE_CAMERA", "error", "La línea requiere un camera token válido al final.", number, max(1, len(raw)), "Ejemplo: (ZI*1.2)."))
+            continue
+        effect = match.group(1)
+        intensity = match.group(2)
+        target = match.group(3)
+        if intensity is not None and float(intensity) <= 0:
+            out.append(diagnostic("E_EFFECT", "error", "La intensidad debe ser mayor que cero.", number, match.start() + 1))
+        if effect != "PP" and target:
+            out.append(diagnostic("E_EFFECT", "error", f"{effect} no admite objetivo.", number, match.start() + 1))
+    if not seen_header:
+        out.append(diagnostic("E_SCRIPT_HEADER", "error", "No se encontró ninguna intervención."))
+    if block_has_header and not block_has_place:
+        out.append(diagnostic("E_PLACE", "error", "El último bloque no termina con **LUGAR**."))
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path)
+    parser.add_argument("--mode", choices=("strict", "legacy"), default="strict")
+    parser.add_argument("--pretty", action="store_true")
+    args = parser.parse_args()
+    try:
+        text = args.input.read_text(encoding="utf-8-sig")
+        data = json.loads(text)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        result = {"valid": False, "diagnostics": [diagnostic("E_JSON_INVALID", "error", str(exc))]}
+        print(json.dumps(result, ensure_ascii=False, indent=2 if args.pretty else None))
+        return 1
+    diagnostics = validate_container(data, args.mode)
+    content = data.get("content") if isinstance(data, dict) else None
+    if isinstance(content, str) and content.strip():
+        diagnostics.extend(validate_script(content, args.mode))
+    else:
+        diagnostics.append(diagnostic("E_SCHEMA", "error", "content debe ser un string no vacío."))
+    diagnostics.sort(key=lambda item: (item["line"], item["column"], item["code"]))
+    valid = not any(item["severity"] == "error" for item in diagnostics)
+    print(json.dumps({"valid": valid, "diagnostics": diagnostics}, ensure_ascii=False, indent=2 if args.pretty else None))
+    return 0 if valid else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/habilidades/empaquetar-episodio-maas/SKILL.md
+++ b/habilidades/empaquetar-episodio-maas/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: empaquetar-episodio-maas
+description: Construye y verifica carpetas HTML estáticas por episodio MAAS, copia assets hasheados autorizados, genera build-report.json y aplica controles de seguridad/publicación. Usar después de compilar y antes de desplegar o compartir un episodio.
+---
+
+# Empaquetar episodio MAAS
+
+1. Leer `references/output-layout.md`, `references/build-security.md` y `references/publication.md`.
+2. Construir primero el player con Vite.
+3. Ejecutar `scripts/build_episode.py MANIFEST --player-dist DIST_PLAYER --output DIST_ROOT`.
+4. Si se incluyen assets, proporcionar asset manifest y raíz de origen; bloquear cualquier asset no autorizado.
+5. Ejecutar `scripts/verify_bundle.py DIST_ROOT --publication`.
+6. Publicar únicamente si el reporte es válido.
+
+## Guardas
+
+- No limpiar ni sobrescribir outputs sin autorización explícita.
+- No insertar contenido con `innerHTML` ni serializar variables de entorno.
+- Mantener rutas relativas y same-origin.
+- No permitir llamadas TTS/OpenAI desde el bundle.

--- a/habilidades/empaquetar-episodio-maas/agents/openai.yaml
+++ b/habilidades/empaquetar-episodio-maas/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Empaquetar episodio MAAS"
+  short_description: "Genera una carpeta HTML estática y segura"
+  default_prompt: "Usa $empaquetar-episodio-maas para construir y verificar la salida estática de un episodio."

--- a/habilidades/empaquetar-episodio-maas/references/build-security.md
+++ b/habilidades/empaquetar-episodio-maas/references/build-security.md
@@ -1,0 +1,10 @@
+# Seguridad de build
+
+- Validar `episodeId` antes de usarlo como ruta.
+- Resolver rutas y comprobar que permanezcan dentro de sus raíces.
+- Prohibir `..`, rutas absolutas, symlinks escapando la raíz y protocolos en paths de assets.
+- Escapar texto mediante APIs de React/Pixi; prohibir `dangerouslySetInnerHTML` e `innerHTML`.
+- CSP mínima: `default-src 'self'`, media/img/connect/script restringidos a self; `data:` solo para imagen aprobada.
+- Buscar patrones de secretos: `OPENAI_API_KEY`, `ELEVEN`, `GOOGLE_SERVICE_ACCOUNT`, claves PEM y tokens Bearer.
+- Source maps de producción son optativos y no deben contener secretos ni paths privados.
+- Dependencias remotas/CDN están prohibidas durante playback.

--- a/habilidades/empaquetar-episodio-maas/references/output-layout.md
+++ b/habilidades/empaquetar-episodio-maas/references/output-layout.md
@@ -1,0 +1,18 @@
+# Layout de salida
+
+```text
+dist/
+├── index.html
+├── assets/<sha256>.<ext>
+└── episodes/<episode-id>/
+    ├── index.html
+    ├── episode.manifest.json
+    └── build-report.json
+```
+
+- `index.html` raíz puede actuar como catálogo.
+- Cada episodio tiene URL propia y carga assets compartidos por hash.
+- No duplicar sprites/audio por episodio.
+- `episode.manifest.json` contiene IDs y URLs resueltas same-origin.
+- `build-report.json` registra hashes de input/output, perfil, warnings, tiempos y herramientas.
+- El bundle debe funcionar desde un servidor estático; no prometer soporte directo de `file://`.

--- a/habilidades/empaquetar-episodio-maas/references/publication.md
+++ b/habilidades/empaquetar-episodio-maas/references/publication.md
@@ -1,0 +1,12 @@
+# Gate de publicación
+
+Publicar solo si:
+
+1. Input, manifiesto y timeline son válidos.
+2. Todos los assets referenciados existen y su SHA coincide.
+3. Todos tienen `allowedForPublish=true`.
+4. No hay secretos, URLs remotas o rutas absolutas.
+5. Las pruebas de paridad y accesibilidad requeridas pasaron.
+6. `build-report.json` registra versiones y warnings aceptados.
+
+Un warning de licencia desconocida se eleva a `E_LICENSE` en `--publication`. Preview puede usar placeholders locales claramente identificados.

--- a/habilidades/empaquetar-episodio-maas/scripts/build_episode.py
+++ b/habilidades/empaquetar-episodio-maas/scripts/build_episode.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Construye una carpeta estática de episodio sin llamadas de red."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import time
+from pathlib import Path
+
+ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def safe_join(root: Path, relative: str) -> Path:
+    if "://" in relative or Path(relative).is_absolute():
+        raise ValueError(f"E_ASSET: ruta no local {relative}")
+    target = (root / relative).resolve()
+    if root.resolve() not in target.parents and target != root.resolve():
+        raise ValueError(f"E_ASSET: ruta fuera de raíz {relative}")
+    return target
+
+
+def copy_new(source: Path, target: Path) -> None:
+    if target.exists():
+        if source.is_file() and sha256(source) == sha256(target):
+            return
+        raise FileExistsError(f"No se sobrescribe {target}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("--player-dist", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--asset-manifest", type=Path)
+    parser.add_argument("--asset-root", type=Path)
+    args = parser.parse_args()
+    started = time.perf_counter()
+    try:
+        manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+        episode_id = str(manifest["episodeId"])
+        if not ID_RE.fullmatch(episode_id):
+            raise ValueError("E_SCHEMA: episodeId no es seguro para ruta")
+        player_dist = args.player_dist.resolve()
+        output = args.output.resolve()
+        if not (player_dist / "index.html").is_file():
+            raise ValueError("E_ASSET: player-dist no contiene index.html")
+        for source in sorted(player_dist.rglob("*")):
+            if source.is_file():
+                copy_new(source, output / source.relative_to(player_dist))
+        episode_dir = output / "episodes" / episode_id
+        copy_new(player_dist / "index.html", episode_dir / "index.html")
+        episode_dir.mkdir(parents=True, exist_ok=True)
+        manifest_target = episode_dir / "episode.manifest.json"
+        payload = json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+        if manifest_target.exists():
+            if manifest_target.read_text(encoding="utf-8") != payload:
+                raise FileExistsError(f"No se sobrescribe {manifest_target}")
+        else:
+            manifest_target.write_text(payload, encoding="utf-8", newline="\n")
+        copied_assets = 0
+        if args.asset_manifest or args.asset_root:
+            if not (args.asset_manifest and args.asset_root):
+                raise ValueError("E_ASSET: proporciona asset-manifest y asset-root juntos")
+            assets = json.loads(args.asset_manifest.read_text(encoding="utf-8"))["assets"]
+            requested = set(manifest.get("assets", []))
+            by_id = {asset["id"]: asset for asset in assets}
+            for asset_id in sorted(requested):
+                asset = by_id.get(asset_id)
+                if not asset:
+                    raise ValueError(f"E_ASSET: {asset_id} ausente")
+                if asset.get("allowedForPublish") is not True:
+                    raise ValueError(f"E_LICENSE: {asset_id}")
+                source = safe_join(args.asset_root.resolve(), asset["path"])
+                if sha256(source) != asset["sha256"]:
+                    raise ValueError(f"E_ASSET: hash distinto para {asset_id}")
+                target = output / "assets" / f"{asset['sha256']}{source.suffix.casefold()}"
+                copy_new(source, target)
+                copied_assets += 1
+        report = {
+            "schemaVersion": "1.0", "episodeId": episode_id, "profile": manifest.get("profile"),
+            "inputSha256": sha256(args.manifest), "manifestSha256": hashlib.sha256(payload.encode()).hexdigest(),
+            "assetCount": copied_assets, "warningCount": len(manifest.get("warnings", [])),
+            "timingsMs": {"total": round((time.perf_counter() - started) * 1000)},
+        }
+        report_path = episode_dir / "build-report.json"
+        if report_path.exists():
+            raise FileExistsError(f"No se sobrescribe {report_path}")
+        report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8", newline="\n")
+        print(json.dumps(report, ensure_ascii=False, sort_keys=True))
+        return 0
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as exc:
+        print(str(exc))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/habilidades/empaquetar-episodio-maas/scripts/verify_bundle.py
+++ b/habilidades/empaquetar-episodio-maas/scripts/verify_bundle.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Verifica estructura, secretos y políticas básicas de un bundle MAAS."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+SECRET_PATTERNS = {
+    "OPENAI_API_KEY": re.compile(r"OPENAI_API_KEY|sk-[A-Za-z0-9_-]{20,}"),
+    "ELEVENLABS": re.compile(r"ELEVEN(?:LABS)?[_-]?(?:API)?[_-]?KEY", re.IGNORECASE),
+    "PRIVATE_KEY": re.compile(r"BEGIN (?:RSA |EC )?PRIVATE KEY"),
+    "BEARER": re.compile(r"Bearer\s+[A-Za-z0-9._-]{20,}", re.IGNORECASE),
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", type=Path)
+    parser.add_argument("--publication", action="store_true")
+    args = parser.parse_args()
+    root = args.root.resolve()
+    diagnostics = []
+    if not (root / "index.html").is_file():
+        diagnostics.append({"code": "E_ASSET", "severity": "error", "message": "Falta index.html raíz"})
+    manifests = sorted(root.glob("episodes/*/episode.manifest.json"))
+    if not manifests:
+        diagnostics.append({"code": "E_ASSET", "severity": "error", "message": "No hay episodios"})
+    for path in root.rglob("*"):
+        if not path.is_file() or path.suffix.casefold() not in {".html", ".js", ".json", ".css", ".map"}:
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for name, pattern in SECRET_PATTERNS.items():
+            if pattern.search(text):
+                diagnostics.append({"code": "E_SECRET", "severity": "error", "path": path.relative_to(root).as_posix(), "message": name})
+        if re.search(r"\b(?:innerHTML|dangerouslySetInnerHTML)\b", text):
+            diagnostics.append({"code": "E_HTML_INJECTION", "severity": "error", "path": path.relative_to(root).as_posix(), "message": "API HTML insegura"})
+        if args.publication and re.search(r"https?://", text) and "json-schema.org" not in text:
+            diagnostics.append({"code": "E_REMOTE_RUNTIME", "severity": "error", "path": path.relative_to(root).as_posix(), "message": "URL remota en bundle"})
+    for manifest_path in manifests:
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            if manifest.get("durationMs", -1) < 0 or not isinstance(manifest.get("timeline"), list):
+                raise ValueError("timeline/duration inválidos")
+            report = manifest_path.with_name("build-report.json")
+            if not report.is_file():
+                diagnostics.append({"code": "E_ASSET", "severity": "error", "path": report.relative_to(root).as_posix(), "message": "Falta build-report"})
+        except (json.JSONDecodeError, ValueError) as exc:
+            diagnostics.append({"code": "E_SCHEMA", "severity": "error", "path": manifest_path.relative_to(root).as_posix(), "message": str(exc)})
+    result = {"valid": not any(d["severity"] == "error" for d in diagnostics), "episodes": len(manifests), "diagnostics": diagnostics}
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0 if result["valid"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/habilidades/migrar-insumos-maas/SKILL.md
+++ b/habilidades/migrar-insumos-maas/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: migrar-insumos-maas
+description: Inventaría, clasifica, mide, deduplica y audita licencias de fondos, sprites, fuentes, voces, música, SFX, transiciones y endings de un repositorio MAAS legado. Usar antes de copiar assets al nuevo repositorio o publicar un episodio HTML.
+---
+
+# Migrar insumos MAAS
+
+1. Leer `references/asset-contract.md` y `references/licensing-policy.md`.
+2. Ejecutar `scripts/build_asset_manifest.py LEGACY_ROOT --output asset-manifest.json`.
+3. Revisar `references/legacy-inventory.md` y comparar conteos/anomalías.
+4. Completar procedencia, autor, licencia y `allowedForPublish` mediante un archivo de overrides revisado.
+5. Ejecutar `scripts/audit_assets.py asset-manifest.json --publication` antes de copiar o publicar.
+6. Copiar solo assets referenciados y autorizados; nunca copiar `Videos/`, `media/clips/` o `media/Caps/` como fuente del nuevo producto.
+
+## Guardas
+
+- No inferir licencia desde un nombre que diga "no copyright".
+- Usar SHA-256 para deduplicar; no borrar duplicados automáticamente.
+- Conservar rutas relativas y no seguir symlinks fuera de la raíz.
+- Marcar metadata desconocida como `null`, no inventarla.

--- a/habilidades/migrar-insumos-maas/agents/openai.yaml
+++ b/habilidades/migrar-insumos-maas/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Migrar insumos MAAS"
+  short_description: "Inventaría y audita los recursos multimedia"
+  default_prompt: "Usa $migrar-insumos-maas para inventariar y migrar los assets del repositorio legado."

--- a/habilidades/migrar-insumos-maas/references/asset-contract.md
+++ b/habilidades/migrar-insumos-maas/references/asset-contract.md
@@ -1,0 +1,46 @@
+# Contrato de assets
+
+## Índice
+
+1. Tipos
+2. Reglas por tipo
+3. IDs y rutas
+4. Fallbacks
+
+## 1. Tipos
+
+`background`, `sprite`, `transition`, `font`, `voice`, `sfx`, `music`, `ending`, `other`.
+
+Cada entrada requiere `id`, `type`, `path`, `sha256`, `mimeType` y `allowedForPublish`. Dimensiones y duración son `null` si no pueden medirse sin error.
+
+## 2. Reglas por tipo
+
+- Fondos: lugar y variante/orientación declarados; actualmente seis PNG por lugar.
+- Sprites: personaje, emoción y mirada; PNG con alpha preferido.
+- Transiciones: imagen de origen, no PNG generado.
+- Fuentes: licencia y archivo de licencia asociados.
+- Audio: duración en ms, codec/MIME y categoría; la clave narrativa vive en un mapping separado.
+- Ending: orientación obligatoria.
+
+## 3. IDs y rutas
+
+Generar IDs ASCII en minúsculas desde la ruta relativa y añadir ocho caracteres del SHA si existe colisión. Usar `/`, prohibir rutas absolutas y `..`. Los nombres originales permanecen en `path` y `aliases`.
+
+## 4. Fallbacks
+
+Los fallbacks son datos explícitos: emoción, mirada, orientación y lugar. No elegir “el primer archivo”. Detectar ciclos y terminar con error si no existe un asset autorizado.
+
+## Overrides revisados
+
+Pasar `--overrides metadata.json`; sus claves son asset IDs y solo puede cambiar procedencia, autor, licencia, autorización, aliases y clasificación visual:
+
+```json
+{
+  "nanum-gothic-bold": {
+    "source": "https://fonts.google.com/specimen/Nanum+Gothic",
+    "author": "Sandoll Communications",
+    "license": "OFL-1.1",
+    "allowedForPublish": true
+  }
+}
+```

--- a/habilidades/migrar-insumos-maas/references/legacy-inventory.md
+++ b/habilidades/migrar-insumos-maas/references/legacy-inventory.md
@@ -1,0 +1,22 @@
+# Inventario observado del repositorio legado
+
+| Grupo | Conteo | Observaciones |
+|---|---:|---|
+| JSON de episodios válidos | 37 | 31 procesados y 6 por procesar al auditar. |
+| Fondos | 54 | 9 lugares × 6 variantes. |
+| Sprites PNG | 145 | 11 directorios; CSV describe 10 personajes. |
+| Fondos de transición | 23 | WebP con nombres DALL·E. |
+| Audio/video fuente | 132 | 125 MP3, 1 M4A y 6 MP4. |
+| Fuentes | 3 TTF por copia | Nanum Gothic está duplicada en dos ubicaciones. |
+
+Anomalías que el script debe reportar:
+
+- `angy` y `condused`.
+- Prefijos `Correct_` y duplicados con `(2)`.
+- `Tortuga` no aparece en el CSV de personajes.
+- `Coneja` tiene cobertura de mirada desigual.
+- Nombres de marcas, juegos, bandas sonoras y “Tiene copyright”.
+- MP4, JPEG y audios generados mezclados con fuentes.
+- Ausencia general de metadata de autor/licencia salvo OFL de Nanum Gothic.
+
+Los conteos son baseline, no una regla eterna. Guardar cada nueva auditoría como JSON para explicar cambios.

--- a/habilidades/migrar-insumos-maas/references/licensing-policy.md
+++ b/habilidades/migrar-insumos-maas/references/licensing-policy.md
@@ -1,0 +1,13 @@
+# Política de licencias y procedencia
+
+`allowedForPublish` inicia en `false`. Solo puede cambiar a `true` cuando existen:
+
+1. Fuente o URL verificable.
+2. Autor o propietario.
+3. Licencia o permiso aplicable.
+4. Evidencia almacenada fuera del archivo binario cuando corresponda.
+5. Alcance compatible con redistribución web.
+
+Un nombre de archivo no es evidencia. Tratar como riesgo elevado referencias a OST, soundtrack, Windows, Roblox, PlayStation, Nintendo, SpongeBob, Kanye West, Halo, Discord, Skype, FNAF o cualquier marca/obra reconocible.
+
+El modo desarrollo puede sustituir assets bloqueados con placeholders. El modo publicación falla con `E_LICENSE`. Nunca incrustar material bloqueado en un HTML autocontenido.

--- a/habilidades/migrar-insumos-maas/scripts/audit_assets.py
+++ b/habilidades/migrar-insumos-maas/scripts/audit_assets.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Audita integridad, duplicados, naming y permiso de publicación."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("--publication", action="store_true")
+    parser.add_argument("--report", type=Path)
+    args = parser.parse_args()
+    data = json.loads(args.manifest.read_text(encoding="utf-8-sig"))
+    diagnostics = []
+    by_hash: dict[str, list[str]] = defaultdict(list)
+    ids: set[str] = set()
+    for asset in data.get("assets", []):
+        asset_id = asset.get("id", "")
+        if asset_id in ids:
+            diagnostics.append({"code": "E_ASSET", "severity": "error", "assetId": asset_id, "message": "ID duplicado"})
+        ids.add(asset_id)
+        by_hash[str(asset.get("sha256"))].append(asset_id)
+        name = str(asset.get("path", "")).casefold()
+        if any(token in name for token in ("angy", "condused", "correct_", " (2)")):
+            diagnostics.append({"code": "W_ASSET_NAMING", "severity": "warning", "assetId": asset_id, "message": "Naming legado irregular"})
+        if not asset.get("license"):
+            diagnostics.append({"code": "W_LICENSE_UNKNOWN", "severity": "warning", "assetId": asset_id, "message": "Licencia sin documentar"})
+        if args.publication and asset.get("allowedForPublish") is not True:
+            diagnostics.append({"code": "E_LICENSE", "severity": "error", "assetId": asset_id, "message": "Asset no autorizado para publicación"})
+    for sha, asset_ids in by_hash.items():
+        if sha and len(asset_ids) > 1:
+            diagnostics.append({"code": "W_DUPLICATE_CONTENT", "severity": "warning", "sha256": sha, "assetIds": asset_ids, "message": "Contenido binario duplicado"})
+    report = {"valid": not any(d["severity"] == "error" for d in diagnostics), "assetCount": len(data.get("assets", [])), "diagnostics": diagnostics}
+    payload = json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.report:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(payload, encoding="utf-8", newline="\n")
+    print(payload, end="")
+    return 0 if report["valid"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/habilidades/migrar-insumos-maas/scripts/build_asset_manifest.py
+++ b/habilidades/migrar-insumos-maas/scripts/build_asset_manifest.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Construye un asset-manifest determinista desde un repositorio MAAS."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import re
+import unicodedata
+from pathlib import Path
+from typing import Any
+
+HERE = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location("probe_media", HERE / "probe_media.py")
+probe_module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(probe_module)
+
+SOURCE_EXTENSIONS = {".png", ".webp", ".jpg", ".jpeg", ".ttf", ".otf", ".mp3", ".m4a", ".wav", ".mp4"}
+EXCLUDED_PARTS = {"Videos", "clips", "Caps", "Audios_personajes", "__pycache__", ".git"}
+
+
+def slug(value: str) -> str:
+    value = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii").lower()
+    return re.sub(r"[^a-z0-9]+", "-", value).strip("-") or "asset"
+
+
+def classify(relative: Path) -> str:
+    lower = "/".join(part.casefold() for part in relative.parts)
+    if "personajes_animales" in lower:
+        return "sprite"
+    if "/fondos/" in f"/{lower}/":
+        return "background"
+    if "transiciones" in lower:
+        return "transition"
+    if relative.suffix.casefold() in {".ttf", ".otf"}:
+        return "font"
+    if "endings" in lower:
+        return "ending"
+    if "background" in lower:
+        return "music"
+    if "efectos" in lower or "ambiente" in lower:
+        return "sfx"
+    if "audios_personajes" in lower:
+        return "voice"
+    return "other"
+
+
+def sprite_fields(relative: Path) -> dict[str, Any]:
+    if "personajes_animales" not in [p.casefold() for p in relative.parts]:
+        return {"character": None, "emotion": None, "gaze": None}
+    character = relative.parent.name
+    stem = relative.stem.removeprefix("Correct_")
+    parts = stem.split("_")
+    gaze = parts[-1].casefold() if parts[-1].casefold() in {"left", "right", "front"} else None
+    emotion = "_".join(parts[:-1]) if gaze else parts[0]
+    return {"character": character, "emotion": emotion, "gaze": gaze}
+
+
+def make_entry(root: Path, path: Path, used: set[str]) -> dict[str, Any]:
+    relative = path.relative_to(root)
+    sha = hashlib.sha256(path.read_bytes()).hexdigest()
+    asset_id = slug(relative.with_suffix("").as_posix())
+    if asset_id in used:
+        asset_id = f"{asset_id}-{sha[:8]}"
+    used.add(asset_id)
+    metadata = probe_module.probe(path)
+    asset_type = classify(relative)
+    fields = sprite_fields(relative)
+    place = relative.parent.name if asset_type == "background" else None
+    orientation = None
+    if asset_type == "ending":
+        orientation = "portrait" if "_v" in relative.stem.casefold() else "landscape"
+    return {
+        "id": asset_id,
+        "type": asset_type,
+        "path": relative.as_posix(),
+        "sha256": sha,
+        **metadata,
+        **fields,
+        "place": place,
+        "orientation": orientation,
+        "aliases": [path.name],
+        "source": None,
+        "author": None,
+        "license": "OFL-1.1" if asset_type == "font" and "nanum" in lower_path(path) else None,
+        "allowedForPublish": bool(asset_type == "font" and "nanum" in lower_path(path)),
+    }
+
+
+def lower_path(path: Path) -> str:
+    return path.as_posix().casefold()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--generated-at", default="1970-01-01T00:00:00Z")
+    parser.add_argument("--overrides", type=Path, help="JSON assetId -> metadata revisada")
+    args = parser.parse_args()
+    root = args.root.resolve()
+    if not root.is_dir():
+        print("E_ASSET: raíz inexistente")
+        return 1
+    paths = []
+    for path in root.rglob("*"):
+        if not path.is_file() or path.suffix.casefold() not in SOURCE_EXTENSIONS:
+            continue
+        relative = path.relative_to(root)
+        if any(part in EXCLUDED_PARTS for part in relative.parts):
+            continue
+        paths.append(path)
+    used: set[str] = set()
+    assets = [make_entry(root, path, used) for path in sorted(paths, key=lambda p: p.as_posix().casefold())]
+    if args.overrides:
+        try:
+            overrides = json.loads(args.overrides.read_text(encoding="utf-8-sig"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            print(f"E_JSON_INVALID: {exc}")
+            return 1
+        by_id = {asset["id"]: asset for asset in assets}
+        unknown = sorted(set(overrides) - set(by_id))
+        if unknown:
+            print(f"E_ASSET: overrides para IDs desconocidos: {unknown}")
+            return 1
+        allowed = {"source", "author", "license", "allowedForPublish", "aliases", "orientation", "place", "character", "emotion", "gaze"}
+        for asset_id, values in overrides.items():
+            if not isinstance(values, dict) or set(values) - allowed:
+                print(f"E_SCHEMA: override inválido para {asset_id}")
+                return 1
+            by_id[asset_id].update(values)
+    manifest = {"schemaVersion": "1.0", "generatedAt": args.generated_at, "assets": assets}
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8", newline="\n")
+    counts: dict[str, int] = {}
+    for asset in assets:
+        counts[asset["type"]] = counts.get(asset["type"], 0) + 1
+    print(json.dumps({"assets": len(assets), "counts": counts, "output": str(args.output)}, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/habilidades/migrar-insumos-maas/scripts/probe_media.py
+++ b/habilidades/migrar-insumos-maas/scripts/probe_media.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Obtiene metadata multimedia sin convertir ni modificar el archivo."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import shutil
+import subprocess
+import wave
+from pathlib import Path
+from typing import Any
+
+
+def probe(path: Path) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "mimeType": mimetypes.guess_type(path.name)[0] or "application/octet-stream",
+        "width": None,
+        "height": None,
+        "durationMs": None,
+    }
+    try:
+        from PIL import Image  # type: ignore
+        if result["mimeType"].startswith("image/"):
+            with Image.open(path) as image:
+                result["width"], result["height"] = image.size
+    except (ImportError, OSError):
+        pass
+    if path.suffix.casefold() == ".wav":
+        try:
+            with wave.open(str(path), "rb") as audio:
+                result["durationMs"] = round(audio.getnframes() / audio.getframerate() * 1000)
+        except (OSError, wave.Error, ZeroDivisionError):
+            pass
+    try:
+        from mutagen import File as MutagenFile  # type: ignore
+        if result["durationMs"] is None and result["mimeType"].startswith(("audio/", "video/")):
+            media = MutagenFile(path)
+            length = getattr(getattr(media, "info", None), "length", None)
+            if length is not None:
+                result["durationMs"] = round(float(length) * 1000)
+    except (ImportError, OSError, ValueError):
+        pass
+    if result["mimeType"].startswith(("audio/", "video/")) and shutil.which("ffprobe"):
+        try:
+            completed = subprocess.run(
+                ["ffprobe", "-v", "error", "-show_streams", "-show_format", "-of", "json", str(path)],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            payload = json.loads(completed.stdout)
+            for stream in payload.get("streams", []):
+                if stream.get("codec_type") == "video":
+                    result["width"] = int(stream["width"]) if stream.get("width") else result["width"]
+                    result["height"] = int(stream["height"]) if stream.get("height") else result["height"]
+                    break
+            raw_duration = payload.get("format", {}).get("duration")
+            if raw_duration is not None:
+                result["durationMs"] = round(float(raw_duration) * 1000)
+        except (OSError, ValueError, KeyError, json.JSONDecodeError, subprocess.SubprocessError):
+            pass
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path)
+    args = parser.parse_args()
+    if not args.path.is_file():
+        print(json.dumps({"error": "E_ASSET", "message": "Archivo inexistente"}, ensure_ascii=False))
+        return 1
+    print(json.dumps({"path": args.path.as_posix(), **probe(args.path)}, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/habilidades/renderizar-escenas-maas/SKILL.md
+++ b/habilidades/renderizar-escenas-maas/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: renderizar-escenas-maas
+description: Implementa el stage React/PixiJS que compone fondos, sprites, texto, orientación y cámara desde episode.manifest.json. Usar al construir el reproductor, adaptar layouts horizontal/vertical, implementar resize o mejorar accesibilidad visual.
+---
+
+# Renderizar escenas MAAS
+
+1. Validar el manifiesto con `$definir-contratos-maas`.
+2. Leer `references/layouts.md` antes de posicionar assets.
+3. Crear el stage según `references/pixi-renderer.md` y reutilizar `assets/pixi-stage-template/`.
+4. Renderizar escena estática a una textura; después aplicar temblor y cámara mediante `$reproducir-efectos-maas`.
+5. Integrar controles y adaptación responsiva según `references/responsive-player.md`.
+6. Exponer captions en DOM aunque el texto visual esté dentro de Pixi.
+
+## Invariantes
+
+- Coordenadas internas enteras sobre 1920×1080.
+- Escalar el canvas con `contain`; no recalcular layouts desde el viewport.
+- Conservar aspect ratio, alpha y orden de capas.
+- Destruir texturas, listeners y `Application` al desmontar.

--- a/habilidades/renderizar-escenas-maas/agents/openai.yaml
+++ b/habilidades/renderizar-escenas-maas/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Renderizar escenas MAAS"
+  short_description: "Compone escenas MAAS con React y PixiJS"
+  default_prompt: "Usa $renderizar-escenas-maas para construir el renderer PixiJS de una escena MAAS."

--- a/habilidades/renderizar-escenas-maas/assets/pixi-stage-template/MaasStage.ts
+++ b/habilidades/renderizar-escenas-maas/assets/pixi-stage-template/MaasStage.ts
@@ -1,0 +1,72 @@
+import { Application, Assets, Container, Sprite, Text, TextStyle } from "pixi.js";
+import { legacyCameraTransform, type EffectCode } from "./effectMath";
+
+export interface VisualCue {
+  id: string;
+  text: string;
+  backgroundUrl?: string;
+  spriteUrl?: string;
+  speakerPosition?: "izquierda" | "derecha";
+  effect: { code: EffectCode; intensity: number };
+}
+
+export class MaasStage {
+  private app = new Application();
+  private viewport = new Container();
+  private camera = new Container();
+  private currentCue?: VisualCue;
+
+  async init(host: HTMLElement): Promise<void> {
+    await this.app.init({ background: "#000", resizeTo: host, antialias: true });
+    host.appendChild(this.app.canvas);
+    this.viewport.addChild(this.camera);
+    this.app.stage.addChild(this.viewport);
+    this.resize(host.clientWidth, host.clientHeight);
+  }
+
+  async show(cue: VisualCue): Promise<void> {
+    this.currentCue = cue;
+    this.camera.removeChildren().forEach((child) => child.destroy());
+    if (cue.backgroundUrl) {
+      const texture = await Assets.load(cue.backgroundUrl);
+      const background = new Sprite(texture);
+      background.width = 1920;
+      background.height = 1080;
+      this.camera.addChild(background);
+    }
+    if (cue.spriteUrl) {
+      const texture = await Assets.load(cue.spriteUrl);
+      const sprite = new Sprite(texture);
+      sprite.setSize(854, 854);
+      sprite.position.set(cue.speakerPosition === "derecha" ? 968 : 300, 308);
+      this.camera.addChild(sprite);
+    }
+    const text = new Text({ text: cue.text, style: new TextStyle({ fontFamily: "Nanum Gothic", fontSize: 80, fill: "#000" }) });
+    text.position.set(cue.speakerPosition === "derecha" ? 348 : 1054, cue.speakerPosition === "derecha" ? 70 : 98);
+    this.camera.addChild(text);
+    this.camera.pivot.set(960, 540);
+    this.camera.position.set(960, 540);
+  }
+
+  update(elapsedMs: number): void {
+    if (!this.currentCue) return;
+    const value = legacyCameraTransform(
+      this.currentCue.effect.code,
+      this.currentCue.effect.intensity,
+      this.currentCue.speakerPosition ?? "izquierda",
+      elapsedMs / 1000,
+    );
+    this.camera.scale.set(value.scale);
+    this.camera.position.set(960 + value.xFraction * 1920, 540 + value.yFraction * 1080);
+  }
+
+  resize(width: number, height: number): void {
+    const scale = Math.min(width / 1920, height / 1080);
+    this.viewport.scale.set(scale);
+    this.viewport.position.set((width - 1920 * scale) / 2, (height - 1080 * scale) / 2);
+  }
+
+  destroy(): void {
+    this.app.destroy(true, { children: true, texture: false, textureSource: false });
+  }
+}

--- a/habilidades/renderizar-escenas-maas/assets/pixi-stage-template/effectMath.ts
+++ b/habilidades/renderizar-escenas-maas/assets/pixi-stage-template/effectMath.ts
@@ -1,0 +1,36 @@
+export type EffectCode = "ES" | "ZI" | "ZO" | "PA-I" | "PA-D" | "TI-A" | "TI-B" | "PP";
+
+export interface CameraTransform {
+  scale: number;
+  xFraction: number;
+  yFraction: number;
+}
+
+export function legacyCameraTransform(
+  code: EffectCode,
+  intensity: number,
+  speakerPosition: "izquierda" | "derecha",
+  timeSeconds: number,
+): CameraTransform {
+  const safeIntensity = intensity > 0 ? intensity : 1;
+  const base = 0.05;
+  const signX = speakerPosition === "izquierda" ? -1 : 1;
+  if (code === "ES") return { scale: 1, xFraction: 0, yFraction: 0 };
+  if (code === "ZI" || code === "ZO") {
+    const zoom = base * safeIntensity * timeSeconds;
+    const scale = code === "ZI" ? 1 + zoom : 1 - zoom;
+    if (scale <= 0) throw new Error(`E_EFFECT: escala no positiva (${scale})`);
+    return { scale, xFraction: signX * base * safeIntensity * timeSeconds / 2, yFraction: 0 };
+  }
+  if (code === "PA-I" || code === "PA-D") {
+    return {
+      scale: 1 + base * safeIntensity * timeSeconds / 2,
+      xFraction: signX * base * safeIntensity * timeSeconds / 4,
+      yFraction: 0,
+    };
+  }
+  if (code === "TI-A" || code === "TI-B") {
+    return { scale: 1, xFraction: 0, yFraction: (code === "TI-A" ? 1 : -1) * base * safeIntensity * timeSeconds };
+  }
+  return { scale: 1 + base * safeIntensity * timeSeconds, xFraction: 0, yFraction: 0 };
+}

--- a/habilidades/renderizar-escenas-maas/references/layouts.md
+++ b/habilidades/renderizar-escenas-maas/references/layouts.md
@@ -1,0 +1,52 @@
+# Layouts observados
+
+## Índice
+
+1. Orientaciones
+2. Fondos
+3. Personajes
+4. Texto
+5. Reflejos
+
+## 1. Orientaciones
+
+- Landscape: stage 1920×1080.
+- Portrait legado: componer un stage lateral 1920×1080 con fondos V y rotar el contenedor completo 90° para salida 1080×1920.
+- Usar `contain` y barras del color de fondo; no estirar.
+
+## 2. Fondos
+
+| Speaker/layout | Landscape | Portrait lateral |
+|---|---|---|
+| centro | `Fondos de personajes.png` (`H C`) | `(3).png` (`V C`) |
+| izquierda | `(1).png` (`H D`) | `(4).png` (`V D`) |
+| derecha | `(2).png` (`H I`) | `(5).png` (`V I`) |
+
+## 3. Personajes a 1920×1080
+
+| Layout | Normal | Grande `PP` |
+|---|---|---|
+| H C izquierda | 1144,364,854,854 | 92,-62,1500,1500 |
+| H C derecha | 120,364,854,854 | 92,-62,1500,1500 |
+| H D | 300,308,854,854 | 92,-62,1500,1500 |
+| H I | 968,308,854,854 | 620,-62,1500,1500 |
+| V C/V D | 252,186,814,814 | -136,-150,1382,1382 |
+| V I | 170,234,692,692 | -310,-182,1474,1474 |
+
+Formato: `left,top,width,height`. Las posiciones pueden salir del lienzo y deben recortarse.
+
+## 4. Texto
+
+- H C: 762,12; ancho máximo 500; fuente 80.
+- H D: 1054,98; ancho 500; fuente 80.
+- H I: 348,70; ancho 500; fuente 84.
+- V C/V D/V I: 1092,232; ancho 600; fuente 84; rotación 270°.
+- Nanum Gothic ExtraBold, negro, sin fondo.
+- En legacy, `PP` no cambia el layout del texto.
+
+## 5. Reflejos
+
+- `H C`: reflejar el último sprite horizontalmente.
+- `H D`: reflejar horizontalmente.
+- `V C` y `V D`: reflejar verticalmente antes de la rotación final.
+- Seleccionar mirada `left` como base y aplicar fallback explícito si falta.

--- a/habilidades/renderizar-escenas-maas/references/pixi-renderer.md
+++ b/habilidades/renderizar-escenas-maas/references/pixi-renderer.md
@@ -1,0 +1,25 @@
+# Arquitectura PixiJS
+
+Orden de capas:
+
+```text
+Application
+└── viewportContainer
+    └── cameraContainer
+        └── flattenedScene(RenderTexture)
+            ├── background
+            ├── sprites
+            └── visualText
+```
+
+1. Cargar assets mediante IDs del manifest.
+2. Componer en `sceneContainer` con coordenadas lógicas.
+3. Renderizar a `RenderTexture` 1920×1080.
+4. Mostrar esa textura en `cameraContainer`.
+5. Aplicar filtro de temblor al sprite aplanado.
+6. Aplicar scale/translation de cámara al contenedor.
+7. Escalar `viewportContainer` para el elemento host.
+
+El filtro de temblor recibe edge map, frame index, seed, displacement 14, factor 1.1 y blend 0.8. Usar sampler mirror para remap y clamp-to-edge para cámara.
+
+No meter controles en el canvas. React administra estado, accesibilidad y DOM; Pixi solo dibuja. Liberar RenderTextures antiguas al cambiar cue.

--- a/habilidades/renderizar-escenas-maas/references/responsive-player.md
+++ b/habilidades/renderizar-escenas-maas/references/responsive-player.md
@@ -1,0 +1,11 @@
+# Reproductor responsivo y accesible
+
+- `orientation=auto` elige portrait si el viewport es más alto que ancho; el usuario puede forzarla.
+- ResizeObserver calcula `scale=min(hostWidth/logicalWidth,hostHeight/logicalHeight)`.
+- Canvas centrado; controles debajo o sobre una zona segura independiente.
+- Botones: iniciar, play/pause, seek, volumen, captions, orientación y pantalla completa.
+- Teclado: espacio play/pause; flechas ±5 s; `m` mute; `c` captions.
+- `prefers-reduced-motion` apaga temblor y reduce cámara solo si la opción es `system`; la timeline y audio no cambian.
+- `aria-live=polite` anuncia speaker y caption sin repetir cada frame.
+- Mantener contraste y focus visibles.
+- Al desmontar: cancelar animation frame, audio y ResizeObserver.

--- a/habilidades/reproducir-efectos-maas/SKILL.md
+++ b/habilidades/reproducir-efectos-maas/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: reproducir-efectos-maas
+description: Especifica, implementa y prueba la cámara, paneo, zoom, close-up, tilt, temblor, filtros, rotaciones y transiciones de MAAS en perfiles legacy-v1 y canonical-v1. Usar al tocar fórmulas visuales, shaders PixiJS, duraciones o fixtures de paridad.
+---
+
+# Reproducir efectos MAAS
+
+1. Leer `references/effects-catalog.md` completo antes de modificar un efecto.
+2. Elegir un perfil; usar `legacy-v1` por defecto para paridad.
+3. Leer la especificación correspondiente y `references/timing-formulas.md`.
+4. Usar `scripts/legacy_effect_math.py` como oráculo numérico de cámara.
+5. Regenerar fixtures con `scripts/export_effect_fixtures.py` y comparar inicio, mitad y final.
+6. Aplicar los efectos al frame aplanado, no a sprites individuales, salvo que `canonical-v1` lo indique.
+
+## Guardas
+
+- Trabajar a tiempo continuo, cuantizando el temblor a 25 FPS.
+- Usar clamp-to-edge para igualar `BORDER_REPLICATE`.
+- No corregir un accidente legado dentro de `legacy-v1`; documentarlo y corregirlo solo en `canonical-v1`.
+- Rechazar zoom-out cuya escala llegue a cero o sea negativa.

--- a/habilidades/reproducir-efectos-maas/agents/openai.yaml
+++ b/habilidades/reproducir-efectos-maas/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Reproducir efectos MAAS"
+  short_description: "Replica cámara, temblor y tiempos legados"
+  default_prompt: "Usa $reproducir-efectos-maas para implementar o verificar los efectos visuales de MAAS."

--- a/habilidades/reproducir-efectos-maas/references/canonical-v1.md
+++ b/habilidades/reproducir-efectos-maas/references/canonical-v1.md
@@ -1,0 +1,13 @@
+# Perfil `canonical-v1`
+
+- `ES`: scale 1, x/y 0 y temblor apagado salvo solicitud explícita.
+- `ZI`/`ZO`: misma magnitud base, anchor centrado o personaje declarado.
+- `PA-I`: cámara hacia izquierda; contenido se desplaza a la derecha.
+- `PA-D`: cámara hacia derecha; contenido se desplaza a la izquierda.
+- `TI-A`: cámara hacia arriba; contenido baja.
+- `TI-B`: cámara hacia abajo; contenido sube.
+- `PP`: exige target, usa layout `G` y zoom centrado en su bounding box.
+- Clamp de escala mínimo 0.1.
+- Las transformaciones siguen siendo lineales por compatibilidad; easing solo puede añadirse en un perfil futuro.
+- Temblor, filtros y transición son propiedades explícitas del cue.
+- Toda aleatoriedad usa `seed` del episodio más ID del cue.

--- a/habilidades/reproducir-efectos-maas/references/effects-catalog.md
+++ b/habilidades/reproducir-efectos-maas/references/effects-catalog.md
@@ -1,0 +1,76 @@
+# Catálogo total de efectos
+
+## Índice
+
+1. Pipeline activo
+2. Cámara
+3. Temblor
+4. Composición
+5. Transiciones
+6. Audio y velocidad
+7. Código inactivo
+
+## 1. Pipeline activo
+
+El renderer histórico crea un JPEG aplanado de 1920×1080, lo transforma en clip de 25 FPS, aplica temblor, después cámara y finalmente audio. Fondo, sprite y texto se mueven juntos.
+
+## 2. Cámara
+
+| Código | Resultado legado | Frecuencia observada |
+|---|---|---:|
+| `PP` | Sprite grande y zoom centrado. El objetivo se ignora para la cámara. | 473 |
+| `ZO` | Zoom negativo y paneo según lado del speaker. | 133 |
+| `PA-D` | Se convierte a zoom-in suave; no usa `D`. | 104 |
+| `PA-I` | Idéntico a `PA-D`; no usa `I`. | 96 |
+| `ES` | Sin cámara; conserva temblor global. | 81 |
+| `ZI` | Zoom-in y paneo según lado del speaker. | 72 |
+| `TI-B` | Traslada contenido hacia arriba. | 17 |
+| `TI-A` | Traslada contenido hacia abajo. | 14 |
+
+Todos comienzan en `t=0`, no tienen easing y usan intensidad 1.0 si se omite o es no positiva.
+
+## 3. Temblor
+
+Parámetros activos:
+
+- 25 FPS y seed igual al índice de frame `floor(t*25)`.
+- Canny bajo 30, alto 120.
+- Desplazamiento aleatorio uniforme ±14 px, multiplicado por 1.1.
+- Kernel 10 corregido a 11 por requerir impar.
+- Remap bilinear con borde reflejado dentro del temblor.
+- Blur gaussiano 3×3.
+- Máscara de bordes normalizada y blur 3×3.
+- Mezcla máxima 0.8 entre frame original y desplazado.
+
+El navegador genera el edge map en build con Python/OpenCV y usa shader WebGL. La cámara usa clamp-to-edge; el shader de temblor usa mirror/repeat para igualar `BORDER_REFLECT`.
+
+## 4. Composición
+
+- Landscape lógico: 1920×1080 a partir de fondos 960×540.
+- Portrait legado: componer lateralmente en 1920×1080 con variantes `(3)` a `(5)`, rotar assets/texto 270° y el resultado final 90°.
+- Reflejar sprites horizontalmente en layouts `H C` y `H D`; verticalmente en `V C` y `V D` según reglas de layout.
+- Texto Nanum Gothic ExtraBold, negro, sin burbuja, wrapping por ancho medido.
+- `Bip bip` se presenta como `%!&$# >:(`.
+- `PP` selecciona coordenadas `G` antes del zoom.
+
+## 5. Transiciones
+
+- Elegir fondo entre 23 WebP mediante seed.
+- Nueve pasadas `PIL.ImageFilter.BLUR` en legado.
+- Aplicar resize-cover y crop centrado.
+- Dividir texto a máximo 3 palabras o 17 caracteres por línea.
+- Ajustar cada línea al ancho menos 40 px.
+- Blanco, centrado horizontal y vertical, separación 20 px.
+- Duración 1900 ms, música gain 0.5 y fade-out 500 ms.
+- Consejo final histórico: 40 ms; se conserva solo en legacy.
+
+## 6. Audio y velocidad
+
+- Fondo de escena gain 0.15 y 44.1 kHz.
+- Silenciar fondo durante SFX/onomatopeya.
+- La llamada actual fija `speed_factor=1`; el default 1.05 está inactivo.
+- Ending sin aceleración efectiva.
+
+## 7. Código inactivo
+
+Documentar, pero no incluir por defecto: blanco y negro, sepia, contorno, sharpen, emboss, inversión, brillo ×1.5, contraste ×1.5 y edge-enhance. Solo `difuso` participa en transiciones.

--- a/habilidades/reproducir-efectos-maas/references/legacy-v1.md
+++ b/habilidades/reproducir-efectos-maas/references/legacy-v1.md
@@ -1,0 +1,23 @@
+# Perfil `legacy-v1`
+
+Sea `i` la intensidad, `t` los segundos y `p` el lado del speaker.
+
+```text
+base = 0.05
+signX = -1 si p == izquierda; +1 en otro caso
+```
+
+| Código | `scale` | `x` como fracción del ancho | `y` como fracción del alto |
+|---|---:|---:|---:|
+| `ES` | 1 | 0 | 0 |
+| `ZI` | `1 + base*i*t` | `signX*(base*i/2)*t` | 0 |
+| `ZO` | `1 - base*i*t` | `signX*(base*i/2)*t` | 0 |
+| `PA-I` | `1 + (base/2)*i*t` | `signX*(base*i/4)*t` | 0 |
+| `PA-D` | Igual a `PA-I` | Igual a `PA-I` | 0 |
+| `TI-A` | 1 | 0 | `+base*i*t` |
+| `TI-B` | 1 | 0 | `-base*i*t` |
+| `PP` | `1 + base*i*t` | 0 | 0 |
+
+El resize del zoom es centrado y luego se recorta al tamaño original. El paneo ocurre antes del zoom. Una escala `<=0` es inválida y debe detener el build.
+
+El temblor se aplica incluso a `ES`. Efectos desconocidos conservan únicamente temblor y emiten warning.

--- a/habilidades/reproducir-efectos-maas/references/timing-formulas.md
+++ b/habilidades/reproducir-efectos-maas/references/timing-formulas.md
@@ -1,0 +1,19 @@
+# Fórmulas de tiempo
+
+## Reproducción
+
+| Elemento | `legacy-v1` | `canonical-v1` |
+|---|---|---|
+| Diálogo con audio | `max(2000,floor((audioMs+200)/1000)*1000)` | `max(declaredMs,audioMs+200)` |
+| Diálogo sin audio | reparto declarado, mínimo 2000 ms | reparto declarado, mínimo 40 ms |
+| Transición | 1900 ms | configurable, default 1900 ms |
+| Fade de transición | 500 ms | configurable |
+| Consejo | 40 ms | desactivado por defecto |
+| Frame de temblor | `floor(t*25)` | igual si está activo |
+| Velocidad final | 1.0 | 1.0 |
+
+`startMs` se acumula con enteros. Web Audio programa cues contra un único `AudioContext.currentTime`; no encadenar `setTimeout`.
+
+## Procesamiento histórico
+
+Las pausas de 6 s por TTS, 2 s por escena y 1 s por imagen no afectan el video y no se migran. El reporte nuevo mide validación, inventario, TTS, compilación, fixtures, bundle y total mediante reloj monotónico.

--- a/habilidades/reproducir-efectos-maas/scripts/export_effect_fixtures.py
+++ b/habilidades/reproducir-efectos-maas/scripts/export_effect_fixtures.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Genera fixtures exhaustivos de efectos legacy-v1."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location("legacy_effect_math", HERE / "legacy_effect_math.py")
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+def build() -> dict:
+    fixtures = []
+    for code in ("ES", "ZI", "ZO", "PA-I", "PA-D", "TI-A", "TI-B", "PP"):
+        for intensity in (1.0, 1.2, 1.5, 2.5):
+            for position in ("izquierda", "derecha"):
+                for duration in (2.0, 5.0, 10.0):
+                    samples = []
+                    invalid = None
+                    for time_seconds in (0.0, duration / 2.0, duration):
+                        try:
+                            value = module.transform(code, intensity, position, time_seconds)
+                            samples.append({"timeSeconds": time_seconds, **module.asdict(value)})
+                        except ValueError as exc:
+                            invalid = str(exc)
+                            break
+                    fixtures.append({"code": code, "intensity": intensity, "position": position, "durationSeconds": duration, "samples": samples, "invalid": invalid})
+    return {"schemaVersion": "1.0", "profile": "legacy-v1", "fps": 25, "fixtures": fixtures}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    payload = json.dumps(build(), ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload, encoding="utf-8", newline="\n")
+    else:
+        print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/habilidades/reproducir-efectos-maas/scripts/legacy_effect_math.py
+++ b/habilidades/reproducir-efectos-maas/scripts/legacy_effect_math.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Oráculo numérico de transformaciones de cámara legacy-v1."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+
+
+@dataclass(frozen=True)
+class Transform:
+    scale: float
+    x_fraction: float
+    y_fraction: float
+
+
+def transform(code: str, intensity: float, position: str, time_seconds: float) -> Transform:
+    if intensity <= 0:
+        intensity = 1.0
+    if time_seconds < 0:
+        raise ValueError("time_seconds no puede ser negativo")
+    code = code.upper()
+    base = 0.05
+    sign_x = -1.0 if position.casefold() == "izquierda" else 1.0
+    if code == "ES":
+        result = Transform(1.0, 0.0, 0.0)
+    elif code in {"ZI", "ZO"}:
+        zoom = base * intensity * time_seconds
+        result = Transform(1.0 + zoom if code == "ZI" else 1.0 - zoom, sign_x * base * intensity * time_seconds / 2.0, 0.0)
+    elif code in {"PA-I", "PA-D"}:
+        result = Transform(1.0 + base * intensity * time_seconds / 2.0, sign_x * base * intensity * time_seconds / 4.0, 0.0)
+    elif code == "TI-A":
+        result = Transform(1.0, 0.0, base * intensity * time_seconds)
+    elif code == "TI-B":
+        result = Transform(1.0, 0.0, -base * intensity * time_seconds)
+    elif code.startswith("PP"):
+        result = Transform(1.0 + base * intensity * time_seconds, 0.0, 0.0)
+    else:
+        result = Transform(1.0, 0.0, 0.0)
+    if result.scale <= 0:
+        raise ValueError(f"E_EFFECT: escala no positiva ({result.scale})")
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("code")
+    parser.add_argument("--intensity", type=float, default=1.0)
+    parser.add_argument("--position", choices=("izquierda", "derecha"), default="izquierda")
+    parser.add_argument("--time", type=float, default=0.0)
+    args = parser.parse_args()
+    print(json.dumps(asdict(transform(args.code, args.intensity, args.position, args.time)), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/habilidades/sincronizar-audio-maas/SKILL.md
+++ b/habilidades/sincronizar-audio-maas/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: sincronizar-audio-maas
+description: Construye y sincroniza voces, onomatopeyas, música, transiciones y endings de MAAS mediante manifiestos y Web Audio API. Usar al medir audio, recalcular resolvedDurationMs, mezclar ganancias, manejar autoplay o diagnosticar drift temporal.
+---
+
+# Sincronizar audio MAAS
+
+1. Leer `references/audio-contract.md` y `references/timeline-model.md`.
+2. Generar TTS solo en build y registrar el asset resultante; no incluir credenciales en la salida.
+3. Ejecutar `scripts/build_audio_cues.py MANIFEST DURATIONS --profile legacy-v1` para recalcular tiempos.
+4. Validar que todos los cues tengan duración y que `durationMs` coincida con el final real.
+5. Implementar scheduling según `references/browser-audio-policy.md`.
+
+## Guardas
+
+- Usar un único reloj de `AudioContext`; no encadenar timers.
+- Reprogramar cues después de seek, pause o suspensión del contexto.
+- Silenciar música durante SFX únicamente en `legacy-v1`; canonical usa ducking configurable.
+- Exigir gesto del usuario antes de autoplay con sonido.

--- a/habilidades/sincronizar-audio-maas/agents/openai.yaml
+++ b/habilidades/sincronizar-audio-maas/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Sincronizar audio MAAS"
+  short_description: "Construye y sincroniza pistas de audio web"
+  default_prompt: "Usa $sincronizar-audio-maas para crear la timeline de voces, música y efectos."

--- a/habilidades/sincronizar-audio-maas/references/audio-contract.md
+++ b/habilidades/sincronizar-audio-maas/references/audio-contract.md
@@ -1,0 +1,43 @@
+# Contrato de audio
+
+## Índice
+
+1. Tipos
+2. TTS legado
+3. Mezcla
+4. Assets ausentes
+
+## 1. Tipos
+
+- `voice`: diálogo sintetizado o grabado.
+- `sfx`: onomatopeya/efecto puntual.
+- `music`: fondo de escena o transición.
+- `ending`: audio incluido en el cierre audiovisual.
+
+Cada cue referencia `assetId`, `gain`, `fadeInMs` y `fadeOutMs`. El asset manifest aporta `durationMs`.
+
+## 2. TTS legado
+
+Referencia histórica para comparación, no obligación del producto:
+
+- Modelo `eleven_multilingual_v2`.
+- Stability 0.78.
+- Similarity boost 0.91.
+- Style 0.0.
+- Speaker boost activo.
+- Un archivo por línea de diálogo.
+
+La espera artificial de seis segundos no forma parte del resultado y se elimina. Cachear por SHA-256 de proveedor, modelo, voz, settings, idioma y texto normalizado.
+
+## 3. Mezcla
+
+`legacy-v1`: voz/SFX gain 1, música de escena 0.15, transición 0.5, fade-out de transición 500 ms, sample rate objetivo 44100. La música se silencia durante SFX y reinicia desde cero en cada escena.
+
+`canonical-v1`: música continua por episodio y ducking configurable, default -12 dB durante voz/SFX.
+
+## 4. Assets ausentes
+
+- Voz ausente: error en publicación; en preview mostrar texto y silencio explícito.
+- SFX ausente: error si la clave fue solicitada.
+- Música ausente: warning si el perfil permite silencio.
+- Nunca buscar por “parecido” en nombres durante reproducción.

--- a/habilidades/sincronizar-audio-maas/references/browser-audio-policy.md
+++ b/habilidades/sincronizar-audio-maas/references/browser-audio-policy.md
@@ -1,0 +1,11 @@
+# Política de audio en navegador
+
+- Mostrar botón “Iniciar episodio” antes de crear/reanudar el `AudioContext`.
+- Mantener controles de play, pause, seek y volumen accesibles por teclado.
+- Usar `AudioBufferSourceNode` por reproducción; no reutilizar nodos terminados.
+- Crear buses `master`, `voice`, `sfx`, `music` con `GainNode`.
+- Programar fades mediante `linearRampToValueAtTime`.
+- Suspender audio al ocultarse la página solo si la reproducción se pausa en paralelo.
+- Recuperar estados `suspended` e `interrupted` sin adelantar la timeline.
+- No depender de carga remota durante playback; precargar y validar assets usados.
+- Mantener captions visibles aunque el audio falle.

--- a/habilidades/sincronizar-audio-maas/references/timeline-model.md
+++ b/habilidades/sincronizar-audio-maas/references/timeline-model.md
@@ -1,0 +1,20 @@
+# Modelo temporal de audio
+
+`legacy-v1`:
+
+```text
+dialogue = max(2000, floor((audioMs + 200) / 1000) * 1000)
+sfx      = duración del cue visual; cortar audio si excede, no repetir si es corto
+transition = 1900 ms
+```
+
+`canonical-v1`:
+
+```text
+dialogue = max(declaredDurationMs, audioMs + 200)
+sfx      = max(40, audioMs)
+```
+
+Recalcular `startMs` secuencialmente con enteros. Actualizar las escenas a partir de sus `cueIds`. La desviación aceptable es ≤20 ms para audio y ≤40 ms para imagen a 25 FPS.
+
+El seek cancela nodos programados, calcula el offset dentro del cue actual y programa los siguientes contra un nuevo origen monotónico.

--- a/habilidades/sincronizar-audio-maas/scripts/build_audio_cues.py
+++ b/habilidades/sincronizar-audio-maas/scripts/build_audio_cues.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Recalcula duraciones y startMs usando un mapa cueId->audioMs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def resolved_duration(cue: dict, audio_ms: int | None, profile: str) -> int:
+    declared = int(cue.get("declaredDurationMs", cue.get("durationMs", 0)))
+    if audio_ms is None:
+        return int(cue.get("durationMs", declared))
+    if cue.get("type") == "dialogue":
+        if profile == "legacy-v1":
+            return max(2000, ((audio_ms + 200) // 1000) * 1000)
+        return max(declared, audio_ms + 200)
+    if cue.get("type") == "sfx":
+        return int(cue.get("durationMs", audio_ms)) if profile == "legacy-v1" else max(40, audio_ms)
+    return int(cue.get("durationMs", audio_ms))
+
+
+def rebuild(manifest: dict, durations: dict[str, int], profile: str) -> dict:
+    narrative = [cue for cue in manifest["timeline"] if cue["type"] != "scene"]
+    scenes = [cue for cue in manifest["timeline"] if cue["type"] == "scene"]
+    cursor = 0
+    cue_by_id = {}
+    for cue in narrative:
+        audio_ms = durations.get(cue["id"])
+        if cue["type"] in {"dialogue", "sfx"}:
+            cue["durationMs"] = resolved_duration(cue, audio_ms, profile)
+            cue["resolvedDurationMs"] = cue["durationMs"]
+            if audio_ms is not None:
+                cue.setdefault("audio", {})["durationMs"] = audio_ms
+        cue["startMs"] = cursor
+        cursor += int(cue["durationMs"])
+        cue_by_id[cue["id"]] = cue
+    for scene in scenes:
+        members = [cue_by_id[cue_id] for cue_id in scene.get("cueIds", []) if cue_id in cue_by_id]
+        if members:
+            scene["startMs"] = members[0]["startMs"]
+            scene["durationMs"] = members[-1]["startMs"] + members[-1]["durationMs"] - scene["startMs"]
+    manifest["profile"] = profile
+    manifest["durationMs"] = cursor
+    manifest["timeline"] = sorted(scenes + narrative, key=lambda cue: (cue["startMs"], cue["id"]))
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("durations", type=Path, help="JSON object cueId -> duración en ms")
+    parser.add_argument("--profile", choices=("legacy-v1", "canonical-v1"), default="legacy-v1")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    try:
+        manifest = json.loads(args.manifest.read_text(encoding="utf-8-sig"))
+        durations = json.loads(args.durations.read_text(encoding="utf-8-sig"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        print(f"E_JSON_INVALID: {exc}")
+        return 1
+    if not isinstance(durations, dict) or any(isinstance(v, bool) or not isinstance(v, int) or v < 0 for v in durations.values()):
+        print("E_TIMELINE: durations debe ser objeto cueId -> entero no negativo")
+        return 1
+    result = rebuild(manifest, durations, args.profile)
+    payload = json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload, encoding="utf-8", newline="\n")
+    else:
+        print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Resumen

- Agrega la carpeta `habilidades/` con nueve skills para reconstruir MAAS como reproductor HTML.
- Incluye documentación, contratos, scripts deterministas, schemas y starter repository.
- Mantiene fuera del PR cualquier cambio externo a `habilidades/`, incluyendo eliminaciones locales de sprites.

## Verificación

- Staged antes del commit: únicamente paths bajo `habilidades/`.
- Commit: `Add habilidades assets`.